### PR TITLE
ci: align release workflow with clawup pattern

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,3 +1,12 @@
+# Automated release management using release-plz
+# - On push to main: creates/updates a release PR with version bump and changelog
+# - When release PR is merged: creates GitHub release with tag
+# - After release is created: dispatches release.yml to build cross-platform binaries
+#
+# Note: Tags created by GITHUB_TOKEN do not trigger other workflows (GitHub limitation).
+# This workflow explicitly dispatches release.yml via the API to work around this.
+# If RELEASE_PLZ_TOKEN (a PAT) is configured, the tag push will also trigger release.yml
+# directly, but the dispatch acts as a reliable fallback.
 name: Release-plz
 
 permissions:
@@ -71,9 +80,6 @@ jobs:
                   repo: context.repo.repo,
                   workflow_id: 'release.yml',
                   ref: tag,
-                  inputs: {
-                    tag: tag,
-                  },
                 });
                 console.log(`✅ Successfully dispatched release.yml for tag: ${tag}`);
                 return;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,6 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to build (e.g. v0.1.0)"
-        required: false
-        type: string
 
 permissions:
   contents: write
@@ -123,7 +118,7 @@ jobs:
           path: ${{ env.ASSET }}
           retention-days: 1
 
-  upload-release-assets:
+  upload:
     name: Upload Release Assets
     needs: build
     runs-on: ubuntu-22.04
@@ -156,11 +151,9 @@ jobs:
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
           files: |
-            artifacts/**/*
+            artifacts/**/*.tar.gz
+            artifacts/**/*.zip
             checksums-sha256.txt
-          generate_release_notes: true
-          fail_on_unmatched_files: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Align the release CI workflow with the [clawup](https://github.com/loonghao/clawup) pattern for consistency across projects.

## Changes

### `release.yml`
- **Simplified `workflow_dispatch`**: Removed `inputs.tag` parameter — the tag is now inferred from `github.ref_name` (either from tag push or dispatch ref), matching clawup's simpler pattern
- **Renamed upload job**: `upload-release-assets` → `upload` for consistency with clawup
- **Cleaner glob patterns**: Upload step now uses `artifacts/**/*.tar.gz` and `artifacts/**/*.zip` instead of `artifacts/**/*` with `fail_on_unmatched_files: false`
- **Removed `generate_release_notes`**: Release notes are already generated by release-plz when creating the GitHub Release

### `release-plz.yml`
- **Simplified dispatch**: Removed `inputs: { tag: tag }` from the workflow dispatch call — the ref alone is sufficient (aligned with clawup's `release-please.yml` pattern)
- **Added detailed header comments**: Explains the GITHUB_TOKEN limitation and PAT fallback pattern

## Release Pipeline (unchanged)

```
Push to main → release-plz creates GitHub Release + tag
                → dispatches release.yml via API
                → builds 8 platform targets
                → uploads to GitHub Release with SHA256 checksums
                → users install via install.sh / install.ps1
```

## Supported Targets (8 platforms)

| Platform | Target | Archive |
|----------|--------|---------|
| Linux x86_64 (glibc) | `x86_64-unknown-linux-gnu` | tar.gz |
| Linux x86_64 (musl) | `x86_64-unknown-linux-musl` | tar.gz |
| Linux aarch64 (glibc) | `aarch64-unknown-linux-gnu` | tar.gz |
| Linux aarch64 (musl) | `aarch64-unknown-linux-musl` | tar.gz |
| macOS x86_64 | `x86_64-apple-darwin` | tar.gz |
| macOS aarch64 | `aarch64-apple-darwin` | tar.gz |
| Windows x86_64 | `x86_64-pc-windows-msvc` | zip |
| Windows aarch64 | `aarch64-pc-windows-msvc` | zip |

## Install Scripts

Install scripts (`install.sh` and `install.ps1`) are already in place and compatible with this release format:

```bash
# Linux / macOS
curl -fsSL https://raw.githubusercontent.com/loonghao/rez-next/main/install.sh | sh

# Windows (PowerShell)
irm https://raw.githubusercontent.com/loonghao/rez-next/main/install.ps1 | iex
```