### PR TITLE
ci: align release workflow with clawup pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,11 +70,6 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Setup build cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: release-${{ matrix.target }}
-
       - name: Install cross (for cross-compilation targets)
         if: matrix.use-cross == true
         run: cargo install cross --git https://github.com/cross-rs/cross
@@ -152,8 +147,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            artifacts/**/*.tar.gz
-            artifacts/**/*.zip
+            artifacts/**/*
             checksums-sha256.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Final alignment of the release workflow with the proven [clawup](https://github.com/loonghao/clawup) CI pattern.

## Changes

- **Remove `rust-cache` from release builds** — Release builds should be clean and reproducible. Caching is appropriate for CI checks but not for release artifact generation.
- **Simplify upload glob pattern** — Changed from `artifacts/**/*.tar.gz` + `artifacts/**/*.zip` to `artifacts/**/*`, matching clawup's simpler and more inclusive pattern.

## Release Pipeline (unchanged)

The full pipeline flow remains:
1. Push to `main` → `release-plz.yml` creates crates.io release + GitHub Release + tag
2. Tag creation dispatches `release.yml` via API (with retry logic)
3. `release.yml` builds 8 platform targets:
   - Linux: x86_64-gnu, x86_64-musl, aarch64-gnu, aarch64-musl
   - macOS: x86_64, aarch64 (Apple Silicon)
   - Windows: x86_64, aarch64
4. Artifacts uploaded to GitHub Release with SHA256 checksums
5. Users install via:
   ```bash
   # Linux / macOS
   curl -fsSL https://raw.githubusercontent.com/loonghao/rez-next/main/install.sh | sh
   ```
   ```powershell
   # Windows
   irm https://raw.githubusercontent.com/loonghao/rez-next/main/install.ps1 | iex
   ```

## Verification

- [x] `release.yml` now matches clawup's pattern exactly
- [x] `release-plz.yml` dispatch already aligned (merged in previous PR)
- [x] Install scripts (`install.sh`, `install.ps1`) are correct and compatible
- [x] CI workflow (`ci.yml`) uses `rust-actions-toolkit` reusable workflow