### PR TITLE
ci: add auto-merge workflow and align fork detection with clawup

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,50 @@
+# Auto-merge PRs from trusted bots (release-plz, renovate)
+# Enables auto-merge on PRs created by these bots so they merge automatically
+# once all required checks pass.
+name: Auto Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable Auto Merge
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.user.login == 'github-actions[bot]' ||
+      github.event.pull_request.user.login == 'release-plz[bot]' ||
+      github.event.pull_request.user.login == 'renovate[bot]'
+    steps:
+      - name: Enable auto-merge
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            console.log(`Enabling auto-merge for PR #${pr.number}: ${pr.title}`);
+            try {
+              await github.graphql(`
+                mutation($pullRequestId: ID!) {
+                  enablePullRequestAutoMerge(input: {
+                    pullRequestId: $pullRequestId,
+                    mergeMethod: SQUASH
+                  }) {
+                    pullRequest {
+                      autoMergeRequest {
+                        enabledAt
+                      }
+                    }
+                  }
+                }
+              `, {
+                pullRequestId: pr.node_id,
+              });
+              console.log(`✅ Auto-merge enabled for PR #${pr.number}`);
+            } catch (error) {
+              console.log(`⚠️ Could not enable auto-merge: ${error.message}`);
+              console.log('This may be expected if auto-merge is not enabled in repo settings.');
+            }

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,7 +24,7 @@ jobs:
   release-plz-release:
     name: Release-plz release
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'loonghao' }}
+    if: ${{ github.event.repository.fork == false }}
     permissions:
       contents: write
     outputs:
@@ -98,7 +98,7 @@ jobs:
   release-plz-pr:
     name: Release-plz PR
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'loonghao' }}
+    if: ${{ github.event.repository.fork == false }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Changes

### 1. Add auto-merge workflow (`.github/workflows/auto-merge.yml`)
- Automatically enables squash-merge for PRs created by trusted bots:
  - `release-plz[bot]`
  - `renovate[bot]`
  - `github-actions[bot]`
- Uses GitHub GraphQL API to enable auto-merge once all required CI checks pass
- Aligns with the clawup project pattern for automated PR management

### 2. Update fork detection in `release-plz.yml`
- Changed from `github.repository_owner == 'loonghao'` to `github.event.repository.fork == false`
- This is more portable and follows the clawup pattern
- Applied to both `release-plz-release` and `release-plz-pr` jobs

## Pipeline Summary

The full release pipeline (aligned with [clawup](https://github.com/loonghao/clawup)):
1. Push to `main` → `release-plz.yml` creates crates.io release + GitHub Release + tag
2. Tag dispatch triggers `release.yml` → builds 8 platform targets
3. Artifacts + SHA256 checksums uploaded to GitHub Release
4. Bot PRs auto-merge when CI passes

Install scripts:
- Linux/macOS: `curl -fsSL https://raw.githubusercontent.com/loonghao/rez-next/main/install.sh | sh`
- Windows: `irm https://raw.githubusercontent.com/loonghao/rez-next/main/install.ps1 | iex`

## Verification
- ✅ `cargo check --all-targets` passes
- ✅ `cargo test` passes (48 tests: 39 lib + 9 integration)
- ✅ Install scripts compatible with release artifact naming