### PR TITLE
ci: improve auto-merge, renovate config, and CI alignment

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-# Auto-merge PRs from trusted bots (release-plz, renovate)
+# Auto-merge PRs from trusted bots (release-please, renovate, dependabot)
 # Enables auto-merge on PRs created by these bots so they merge automatically
 # once all required checks pass.
 name: Auto Merge
@@ -18,8 +18,28 @@ jobs:
     if: >-
       github.event.pull_request.user.login == 'github-actions[bot]' ||
       github.event.pull_request.user.login == 'release-please[bot]' ||
-      github.event.pull_request.user.login == 'renovate[bot]'
+      github.event.pull_request.user.login == 'renovate[bot]' ||
+      github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
+      - name: Approve PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            console.log(`Approving PR #${pr.number}: ${pr.title}`);
+            try {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                event: 'APPROVE',
+                body: 'Auto-approved: trusted bot PR'
+              });
+              console.log(`✅ Approved PR #${pr.number}`);
+            } catch (error) {
+              console.log(`⚠️ Could not approve PR: ${error.message}`);
+            }
+
       - name: Enable auto-merge
         uses: actions/github-script@v8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,4 @@ jobs:
       # Disable release build consistency test in CI
       # (release builds are validated by the release workflow itself)
       test-release-builds: false
+    secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,8 +5,6 @@
 #
 # Note: Tags created by GITHUB_TOKEN do not trigger other workflows (GitHub limitation).
 # This workflow explicitly dispatches release.yml via the API to work around this.
-# If RELEASE_PLZ_TOKEN (a PAT) is configured, the tag push will also trigger release.yml
-# directly, but the dispatch acts as a reliable fallback.
 # See: https://github.com/googleapis/release-please-action
 name: Release Please
 permissions:

--- a/justfile
+++ b/justfile
@@ -20,9 +20,9 @@ test:
 test-verbose:
     vx cargo test --workspace -- --nocapture
 
-# Run clippy lints
+# Run clippy lints (mirrors CI: --all-features --all-targets -D warnings)
 lint:
-    vx cargo clippy --workspace --all-targets -- -D warnings
+    vx cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 # Format code
 fmt:

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ]
+    "config:recommended",
+    ":rebaseStalePrs"
+  ],
+  "labels": ["dependencies"],
+  "automerge": true,
+  "automergeType": "pr",
+  "platformAutomerge": true,
+  "rebaseWhen": "behind-base-branch"
 }


### PR DESCRIPTION
## Summary

Improve CI/CD pipeline reliability and bot PR handling, aligned with [clawup](https://github.com/loonghao/clawup) reference project.

## Changes

### Auto-merge workflow improvements
- Add `dependabot[bot]` to trusted bots list (was missing, only had renovate and release-please)
- Add auto-approve step before enabling auto-merge (some repos require approval before merge)

### CI workflow
- Add `secrets: inherit` for codecov token passthrough to reusable workflow

### Renovate config enhancements
- Enable `automerge` and `platformAutomerge` for automated dependency updates
- Add `rebaseStalePrs` to automatically rebase outdated bot PRs against latest main
- Set `rebaseWhen: behind-base-branch` to ensure PRs stay up-to-date

### justfile alignment
- Align `lint` command with CI (add `--all-features` flag to match `rust-actions-toolkit` reusable workflow)

## Context

Bot PRs (#66, #60, #55, etc.) were failing CI because their base SHA was outdated. With `rebaseStalePrs` enabled, renovate will automatically rebase these PRs against latest main, allowing CI to pass and auto-merge to kick in.

## Verification

All CI checks pass locally:
- `vx just lint` ✅
- `vx just test` ✅
- `vx just doc-check` ✅
- `vx just fmt-check` ✅