### PR TITLE
ci: fix release trigger to use release published event

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,16 +1,13 @@
 # Automated release management using release-please
 # - On push to main: creates/updates a release PR with version bump and changelog
 # - When release PR is merged: creates GitHub release with tag
-# - After release is created: dispatches release.yml to build cross-platform binaries
+# - release.yml automatically triggers on 'release: published' to build binaries
 #
-# Note: Tags created by GITHUB_TOKEN do not trigger other workflows (GitHub limitation).
-# This workflow explicitly dispatches release.yml via the API to work around this.
 # See: https://github.com/googleapis/release-please-action
 name: Release Please
 permissions:
   contents: write
   pull-requests: write
-  actions: write
 on:
   push:
     branches:
@@ -21,53 +18,9 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     if: ${{ github.event.repository.fork == false }}
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
     steps:
       - name: Run release-please
         id: release
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
-
-  trigger-release-build:
-    name: Trigger Release Build
-    needs: release-please
-    runs-on: ubuntu-latest
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    steps:
-      - name: Wait for tag to propagate
-        run: sleep 15
-
-      - name: Dispatch release workflow
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
-          script: |
-            const tag = '${{ needs.release-please.outputs.tag_name }}';
-            const maxRetries = 3;
-            const baseDelay = 15000; // 15 seconds
-
-            for (let attempt = 1; attempt <= maxRetries; attempt++) {
-              try {
-                console.log(`Attempt ${attempt}/${maxRetries}: Dispatching release.yml for tag ${tag}`);
-                await github.rest.actions.createWorkflowDispatch({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: 'release.yml',
-                  ref: tag,
-                });
-                console.log(`✅ Successfully dispatched release.yml for tag: ${tag}`);
-                return;
-              } catch (error) {
-                console.log(`❌ Attempt ${attempt} failed: ${error.message}`);
-                if (attempt === maxRetries) {
-                  throw new Error(`Failed to dispatch release.yml after ${maxRetries} attempts: ${error.message}`);
-                }
-                const delay = baseDelay * attempt;
-                console.log(`⏳ Waiting ${delay / 1000}s before retry (tag may still be propagating)...`);
-                await new Promise(resolve => setTimeout(resolve, delay));
-              }
-            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,13 @@
 # Release workflow — build cross-platform binaries and upload to GitHub Release
 # Triggered by:
-#   1. Tag push matching v*
-#   2. Workflow dispatch from release-plz.yml after creating a GitHub Release
+#   1. GitHub Release published (primary — from release-please)
+#   2. Tag push matching v* (fallback)
+#   3. Manual workflow dispatch
 name: Release
 
 on:
+  release:
+    types: [published]
   push:
     tags:
       - "v*"


### PR DESCRIPTION
## Summary

Fix the release pipeline so that cross-platform binaries are reliably built when a release is created.

## Problem

v0.1.1 was released but has **no binary artifacts**. The previous approach used `workflow_dispatch` from `release-please.yml` to trigger `release.yml`, which was unreliable due to:
1. Tag propagation delays (even with retries)
2. `GITHUB_TOKEN`-created tags don't trigger `on: push: tags` workflows
3. Complex retry logic with potential failure modes

## Solution

**`release.yml`**: Add `release: published` event trigger (primary, most reliable)
- When release-please creates a GitHub Release, the `release: published` event fires immediately
- `softprops/action-gh-release` automatically detects the correct release from `GITHUB_REF`
- Keep `push: tags: v*` and `workflow_dispatch` as fallbacks

**`release-please.yml`**: Remove the `trigger-release-build` job
- No longer needed since `release.yml` directly listens for `release: published`
- Removes ~40 lines of complex dispatch/retry logic
- Removes unnecessary `actions: write` permission

## Release Pipeline (after fix)

```
push to main → release-please creates/updates PR
                    ↓ (merge)
              creates GitHub Release + tag
                    ↓ (release: published event)
              release.yml builds 8 platform targets
                    ↓
              uploads to GitHub Release + SHA256 checksums
```

## Verification

After merge, the next release-please cycle will create a release PR. When merged, the `release: published` event will trigger `release.yml` to build 8-platform binaries.

## Next Step

After this PR merges, manually trigger `release.yml` via workflow_dispatch for the existing `v0.1.1` tag to backfill missing binaries.