### PR TITLE
fix: restore trigger-release-build job for reliable binary releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,13 +1,20 @@
 # Automated release management using release-please
 # - On push to main: creates/updates a release PR with version bump and changelog
 # - When release PR is merged: creates GitHub release with tag
-# - release.yml automatically triggers on 'release: published' to build binaries
+# - After release is created: dispatches release.yml to build cross-platform binaries
 #
+# Note: Tags created by GITHUB_TOKEN do not trigger other workflows (GitHub limitation).
+# This workflow explicitly dispatches release.yml via the API to work around this.
+# If RELEASE_PLZ_TOKEN (a PAT) is configured, the tag push will also trigger release.yml
+# directly, but the dispatch acts as a reliable fallback.
 # See: https://github.com/googleapis/release-please-action
 name: Release Please
+
 permissions:
   contents: write
   pull-requests: write
+  actions: write
+
 on:
   push:
     branches:
@@ -18,9 +25,52 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     if: ${{ github.event.repository.fork == false }}
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      version: ${{ steps.release.outputs.version }}
     steps:
       - name: Run release-please
         id: release
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
+
+  trigger-release-build:
+    name: Trigger Release Build
+    needs: release-please
+    runs-on: ubuntu-latest
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    steps:
+      - name: Wait for tag to propagate
+        run: sleep 15
+
+      - name: Dispatch release workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = '${{ needs.release-please.outputs.tag_name }}';
+            const maxRetries = 3;
+            const baseDelay = 15000; // 15 seconds
+
+            for (let attempt = 1; attempt <= maxRetries; attempt++) {
+              try {
+                console.log(`Attempt ${attempt}/${maxRetries}: Dispatching release.yml for tag ${tag}`);
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'release.yml',
+                  ref: tag,
+                });
+                console.log(`✅ Successfully dispatched release.yml for tag: ${tag}`);
+                return;
+              } catch (error) {
+                console.log(`❌ Attempt ${attempt} failed: ${error.message}`);
+                if (attempt === maxRetries) {
+                  throw new Error(`Failed to dispatch release.yml after ${maxRetries} attempts: ${error.message}`);
+                }
+                const delay = baseDelay * attempt;
+                console.log(`⏳ Waiting ${delay / 1000}s before retry (tag may still be propagating)...`);
+                await new Promise(resolve => setTimeout(resolve, delay));
+              }
+            }


### PR DESCRIPTION
## Summary

Restore the `trigger-release-build` job in `release-please.yml` that was removed in PR #69. This ensures reliable binary builds when merging to main triggers a release.

## Problem

v0.1.1 release has **no binary artifacts** because:
1. PR #69 removed the `trigger-release-build` job (dispatch + retry logic) from `release-please.yml`
2. The `release: published` event was expected to trigger `release.yml` directly, but this doesn't always work reliably when the tag is created by `GITHUB_TOKEN` (GitHub limitation)
3. `workflow_dispatch` was triggered manually for backfill but may not have had the correct ref context

## Fix

Restore the `trigger-release-build` job (aligned with [clawup](https://github.com/loonghao/clawup)):
- After release-please creates a GitHub Release, wait 15s for tag propagation
- Explicitly dispatch `release.yml` via GitHub API with the tag ref
- Retry up to 3 times with exponential backoff
- This acts as a reliable fallback alongside `release: published` trigger

## Release Pipeline (after merge)
```
push to main → release-please creates/updates PR
                    ↓ (merge)
              creates GitHub Release + tag
                    ↓ (release: published event + dispatch fallback)
              release.yml builds 8 platform targets
                    ↓
              uploads to GitHub Release + SHA256 checksums
```

## Testing
- Pipeline structure matches clawup's proven working configuration
- CI checks (fmt, clippy, tests) will validate the change
- Next release will verify binary builds work end-to-end