### PR TITLE
fix: restore trigger-release-build and fix CI musl test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,4 @@ jobs:
       # Disable release build consistency test in CI
       # (release builds are validated by the release workflow itself)
       test-release-builds: false
-      # Skip musl target test (known flaky in cross-compilation CI)
-      skip-musl-test: true
     secrets: inherit


### PR DESCRIPTION
Closing in favor of a new PR that replaces the reusable CI workflow with a custom ci.yml to resolve the preexisting flaky musl test, while also including the trigger-release-build improvement.