### PR TITLE
fix: stabilize release ci checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,18 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: loonghao/vx@main
+        with:
+          tools: "actionlint"
+          cache: "true"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: vx actionlint
+
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
@@ -194,8 +206,8 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           pip install maturin pytest pytest-benchmark
-          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
-          echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> "$GITHUB_ENV"
+          echo "$VIRTUAL_ENV/bin" >> "$GITHUB_PATH"
       - name: Build and install Python binding (dev mode)
         working-directory: crates/rez-next-python
         run: maturin develop --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,31 +85,38 @@ jobs:
 
       - name: Build binary
         shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+          USE_CROSS: ${{ matrix.use-cross == true }}
         run: |
-          if [ "${{ matrix.use-cross }}" = "true" ]; then
-            cross build --release --target ${{ matrix.target }}
+          if [ "$USE_CROSS" = "true" ]; then
+            cross build --release --target "$TARGET"
           else
-            cargo build --release --target ${{ matrix.target }}
+            cargo build --release --target "$TARGET"
           fi
 
       - name: Prepare archive (Unix)
         if: matrix.archive == 'tar.gz'
         shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
-          BINARY="target/${{ matrix.target }}/release/${BINARY_NAME}"
-          ARCHIVE="${BINARY_NAME}-${{ matrix.target }}.tar.gz"
+          BINARY="target/${TARGET}/release/${BINARY_NAME}"
+          ARCHIVE="${BINARY_NAME}-${TARGET}.tar.gz"
           chmod +x "$BINARY"
-          tar czf "$ARCHIVE" -C "target/${{ matrix.target }}/release" "${BINARY_NAME}"
-          echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
+          tar czf "$ARCHIVE" -C "target/${TARGET}/release" "${BINARY_NAME}"
+          echo "ASSET=$ARCHIVE" >> "$GITHUB_ENV"
 
       - name: Prepare archive (Windows)
         if: matrix.archive == 'zip'
         shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
-          BINARY="target/${{ matrix.target }}/release/${BINARY_NAME}.exe"
-          ARCHIVE="${BINARY_NAME}-${{ matrix.target }}.zip"
+          BINARY="target/${TARGET}/release/${BINARY_NAME}.exe"
+          ARCHIVE="${BINARY_NAME}-${TARGET}.zip"
           7z a "$ARCHIVE" "$BINARY"
-          echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
+          echo "ASSET=$ARCHIVE" >> "$GITHUB_ENV"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
@@ -177,7 +184,9 @@ jobs:
       - uses: loonghao/vx@main
         with:
           tools: "maturin"
-          cache: "true"
+          # The Windows post-job cache save can fail after a successful wheel build
+          # while archiving ~/.vx, which marks the whole release as failed.
+          cache: ${{ matrix.name != 'windows' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain
@@ -248,7 +257,8 @@ jobs:
           echo "=== Listing dist/ ==="
           ls -la dist/ || echo "(dist is empty or missing)"
           echo "=== Installing wheel with test extras ==="
-          python -m pip install dist/*.whl[test]
+          wheels=(dist/*.whl)
+          python -m pip install "${wheels[0]}[test]"
           echo "=== Installed packages ==="
           python -m pip show rez-next || true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,6 +1614,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1630,7 @@ checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/rez-next-build/Cargo.toml
+++ b/crates/rez-next-build/Cargo.toml
@@ -35,7 +35,7 @@ default = ["git"]
 [dependencies.git2]
 version = "0.20"
 optional = true
-features = ["vendored-libgit2"]
+features = ["vendored-libgit2", "vendored-openssl"]
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/justfile
+++ b/justfile
@@ -29,6 +29,10 @@ lint:
 lint-ci:
     vx cargo clippy --workspace --all-targets --all-features --exclude rez-next-python -- -A warnings -D clippy::correctness
 
+# Check GitHub Actions workflows
+actionlint:
+    vx actionlint
+
 # Format code
 fmt:
     vx cargo fmt --all
@@ -45,7 +49,7 @@ run *ARGS:
 check: fmt-check lint test
 
 # Run all CI checks locally (mirrors GitHub Actions)
-ci: fmt-check lint-ci doc-check test
+ci: actionlint fmt-check lint-ci doc-check test
 
 # Check documentation builds without warnings
 doc:

--- a/vx.toml
+++ b/vx.toml
@@ -1,4 +1,5 @@
 [tools]
+actionlint = "latest"
 cargo-llvm-cov = "latest"
 just = "latest"
 maturin = "latest"
@@ -13,6 +14,7 @@ auto_install = true
 cache_duration = "7d"
 
 [scripts]
+actionlint = "just actionlint"
 bench = "cargo bench"
 build = "just build"
 build-bin = "just build-bin"


### PR DESCRIPTION
## Summary

- Enable vendored OpenSSL for the `git2` dependency used by `rez-next-build`, so release cross-compilation does not depend on target OpenSSL packages being present in CI images.
- Disable `loonghao/vx` cache saving for Windows wheel builds to avoid post-job cache archive failures marking successful wheel builds as failed.
- Add `vx actionlint` to local project tooling and CI so workflow syntax and expressions are checked automatically.

## Validation

- `vx actionlint`
- `vx cargo check -p rez-next-build`
- `git diff --check`

Note: `vx just actionlint` was not runnable in the local Windows shell because this checkout's `just` default shell expects `sh`, but the underlying `vx actionlint` command passed and the CI job runs on Ubuntu.