### PR TITLE
fix: support standard rez build env vars

### DIFF
--- a/crates/rez-next-build/src/environment.rs
+++ b/crates/rez-next-build/src/environment.rs
@@ -6,6 +6,8 @@ use rez_next_package::{Package, PackageRequirement};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+const DEFAULT_BUILD_VERSION: &str = "0.0.0";
+
 /// Build environment for package builds
 #[derive(Debug, Clone)]
 pub struct BuildEnvironment {
@@ -51,7 +53,7 @@ impl BuildEnvironment {
                     .version
                     .as_ref()
                     .map(|v| v.as_str())
-                    .unwrap_or("unknown"),
+                    .unwrap_or(DEFAULT_BUILD_VERSION),
             )
         } else {
             package_build_dir.join("install")
@@ -76,19 +78,18 @@ impl BuildEnvironment {
         env_vars.insert("REZ_BUILD_INSTALL".to_string(), install_flag.to_string());
 
         // Add package-specific variables
+        let package_version = package
+            .version
+            .as_ref()
+            .map(|version| version.as_str().to_string())
+            .unwrap_or_else(|| DEFAULT_BUILD_VERSION.to_string());
         env_vars.insert("REZ_BUILD_PACKAGE_NAME".to_string(), package.name.clone());
         env_vars.insert("REZ_BUILD_PROJECT_NAME".to_string(), package.name.clone());
-
-        if let Some(ref version) = package.version {
-            env_vars.insert(
-                "REZ_BUILD_PACKAGE_VERSION".to_string(),
-                version.as_str().to_string(),
-            );
-            env_vars.insert(
-                "REZ_BUILD_PROJECT_VERSION".to_string(),
-                version.as_str().to_string(),
-            );
-        }
+        env_vars.insert(
+            "REZ_BUILD_PACKAGE_VERSION".to_string(),
+            package_version.clone(),
+        );
+        env_vars.insert("REZ_BUILD_PROJECT_VERSION".to_string(), package_version);
 
         env_vars.insert(
             "REZ_BUILD_INSTALL_PATH".to_string(),
@@ -118,6 +119,7 @@ impl BuildEnvironment {
         env_vars.insert("REZ_BUILD_VARIANT_REQUIRES".to_string(), String::new());
         env_vars.insert("REZ_BUILD_VARIANT_SUBPATH".to_string(), String::new());
         Self::set_build_requirements(&mut env_vars, package, &[]);
+        Self::set_package_file_vars(&mut env_vars, package, None);
 
         // Add context environment if available
         if let Some(context) = context {
@@ -204,16 +206,50 @@ impl BuildEnvironment {
             source_path.to_string_lossy().to_string(),
         );
 
-        let project_file = self
-            .package
-            .filepath
-            .as_deref()
-            .map(PathBuf::from)
-            .unwrap_or_else(|| source_path.join("package.py"));
+        let project_file = Self::project_file_for_source(&self.package, source_path);
         self.env_vars.insert(
             "REZ_BUILD_PROJECT_FILE".to_string(),
             project_file.to_string_lossy().to_string(),
         );
+    }
+
+    fn set_package_file_vars(
+        env_vars: &mut HashMap<String, String>,
+        package: &Package,
+        source_path: Option<&Path>,
+    ) {
+        let Some(project_file) = source_path
+            .map(|path| Self::project_file_for_source(package, path))
+            .or_else(|| package.filepath.as_deref().map(PathBuf::from))
+        else {
+            return;
+        };
+
+        env_vars.insert(
+            "REZ_BUILD_PROJECT_FILE".to_string(),
+            project_file.to_string_lossy().to_string(),
+        );
+        if let Some(parent) = project_file.parent() {
+            env_vars.insert(
+                "REZ_BUILD_SOURCE_PATH".to_string(),
+                parent.to_string_lossy().to_string(),
+            );
+        }
+    }
+
+    fn project_file_for_source(package: &Package, source_path: &Path) -> PathBuf {
+        if let Some(filepath) = package.filepath.as_deref() {
+            return PathBuf::from(filepath);
+        }
+
+        for filename in ["package.py", "package.yaml", "package.yml"] {
+            let candidate = source_path.join(filename);
+            if candidate.exists() {
+                return candidate;
+            }
+        }
+
+        source_path.join("package.py")
     }
 
     fn set_build_requirements(

--- a/crates/rez-next-build/src/tests.rs
+++ b/crates/rez-next-build/src/tests.rs
@@ -516,6 +516,61 @@ for name, check in checks.items():
         }
     }
 
+    #[tokio::test]
+    async fn test_build_manager_sets_standard_rez_build_env_for_versionless_package() {
+        let mut manager = BuildManager::new();
+        let tmp = TempDir::new().unwrap();
+
+        std::fs::write(tmp.path().join("package.py"), "name = 'versionless'\n").unwrap();
+        std::fs::write(
+            tmp.path().join("rezbuild.py"),
+            r#"
+import os
+import sys
+
+required = [
+    "REZ_BUILD_ENV",
+    "REZ_BUILD_INSTALL",
+    "REZ_BUILD_INSTALL_PATH",
+    "REZ_BUILD_PATH",
+    "REZ_BUILD_PROJECT_DESCRIPTION",
+    "REZ_BUILD_PROJECT_FILE",
+    "REZ_BUILD_PROJECT_NAME",
+    "REZ_BUILD_PROJECT_VERSION",
+    "REZ_BUILD_REQUIRES",
+    "REZ_BUILD_REQUIRES_UNVERSIONED",
+    "REZ_BUILD_SOURCE_PATH",
+    "REZ_BUILD_THREAD_COUNT",
+    "REZ_BUILD_TYPE",
+    "REZ_BUILD_VARIANT_INDEX",
+    "REZ_BUILD_VARIANT_REQUIRES",
+    "REZ_BUILD_VARIANT_SUBPATH",
+]
+
+missing = [name for name in required if name not in os.environ]
+if missing:
+    print("missing: " + ", ".join(missing), file=sys.stderr)
+    sys.exit(1)
+
+if os.environ["REZ_BUILD_PROJECT_VERSION"] != "0.0.0":
+    print("unexpected project version", file=sys.stderr)
+    sys.exit(1)
+"#,
+        )
+        .unwrap();
+
+        let pkg = Package::new("versionless".to_string());
+        let req = make_request(pkg, tmp.path().to_path_buf());
+        let ids = manager.start_build(req).await.unwrap();
+        let result = manager.wait_for_build(&ids[0]).await.unwrap();
+
+        assert!(
+            result.success,
+            "rezbuild.py should receive all standard Rez build env vars: {}",
+            result.errors
+        );
+    }
+
     #[test]
     fn test_build_system_detect_with_ambiguous_files() {
         let tmp = TempDir::new().unwrap();

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -321,28 +321,8 @@ fn copy_dir_recursive(src: &PathBuf, dest: &PathBuf) -> RezCoreResult<()> {
 
 /// Load package from current directory
 fn load_current_package(working_dir: &Path) -> RezCoreResult<Package> {
-    use rez_next_package::serialization::PackageSerializer;
-
-    // Look for package.py or package.yaml
-    let package_py = working_dir.join("package.py");
-    let package_yaml = working_dir.join("package.yaml");
-
-    if package_py.exists() {
-        // Use the existing PackageSerializer to load Python packages
-        return PackageSerializer::load_from_file(&package_py)
-            .map_err(|e| RezCoreError::PackageParse(format!("Failed to parse package.py: {}", e)));
-    }
-
-    if package_yaml.exists() {
-        // Use the existing PackageSerializer to load YAML packages
-        return PackageSerializer::load_from_file(&package_yaml).map_err(|e| {
-            RezCoreError::PackageParse(format!("Failed to parse package.yaml: {}", e))
-        });
-    }
-
-    Err(RezCoreError::PackageParse(
-        "No package.py or package.yaml found in current directory".to_string(),
-    ))
+    Package::from_path(working_dir)
+        .map_err(|e| RezCoreError::PackageParse(format!("Failed to load package: {}", e)))
 }
 
 /// Parse build arguments string into vector


### PR DESCRIPTION
## Summary
- Always provide standard Rez build version env vars for versionless packages using a valid fallback version.
- Preserve package file metadata during CLI package loading so build env paths point at the package definition.
- Add regression coverage for versionless packages receiving the standard Rez build env set.

## Validation
- `vx cargo test -p rez-next-build`
- `vx cargo check -p rez-next`