### PR TITLE
feat: add live build events and plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ crates/rez-next-python/test_venv/
 *.temp
 
 # Build artifacts
+.rez_build/
 *.whl
 *.tar.gz
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +128,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,7 +144,16 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -188,10 +217,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -209,16 +268,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -251,7 +350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -297,6 +396,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,7 +436,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -362,10 +471,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -395,12 +533,36 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -472,10 +634,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "derive_more 2.1.1",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "crypto-common"
@@ -487,6 +686,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
 name = "ctor"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +703,40 @@ checksum = "6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -511,6 +754,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,12 +775,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl 2.1.1",
 ]
 
 [[package]]
@@ -536,8 +811,32 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -546,9 +845,9 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.0",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -580,7 +879,16 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -621,16 +929,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -741,7 +1101,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -771,6 +1131,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -829,7 +1199,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -894,6 +1264,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -920,6 +1301,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "http"
@@ -1143,6 +1533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1572,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,7 +1617,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1218,6 +1645,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,7 +1671,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -1250,7 +1686,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1269,7 +1705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1305,10 +1741,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
 name = "lalrpop-util"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -1378,6 +1837,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "link-section"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1870,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1892,15 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
@@ -1430,6 +1913,37 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
 
 [[package]]
 name = "malachite"
@@ -1460,7 +1974,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d149aaa2965d70381709d9df4c7ee1fc0de1c614a4efc2ee356f5e43d68749f8"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "malachite",
  "num-integer",
  "num-traits",
@@ -1505,10 +2019,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1527,8 +2062,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1536,6 +2095,17 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-integer"
@@ -1566,12 +2136,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1642,6 +2221,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,10 +2269,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "phf"
@@ -1692,6 +2333,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros",
  "phf_shared",
 ]
 
@@ -1713,6 +2355,19 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1801,7 +2456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1855,7 +2510,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1868,7 +2523,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1885,7 +2540,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1907,7 +2562,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2025,6 +2680,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.1",
+ "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru 0.16.4",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,7 +2790,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2061,7 +2801,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2141,7 +2881,9 @@ dependencies = [
  "chrono",
  "clap",
  "criterion",
+ "crossterm",
  "libc",
+ "ratatui",
  "regex",
  "rez-next-bind",
  "rez-next-build",
@@ -2159,7 +2901,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "windows-sys 0.61.2",
 ]
@@ -2171,7 +2913,7 @@ dependencies = [
  "regex",
  "rez-next-common",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2179,6 +2921,7 @@ name = "rez-next-build"
 version = "0.3.0"
 dependencies = [
  "async-trait",
+ "flate2",
  "git2",
  "hex",
  "reqwest",
@@ -2188,13 +2931,15 @@ dependencies = [
  "rez-next-version",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
+ "tar",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
  "uuid",
+ "zip",
 ]
 
 [[package]]
@@ -2208,7 +2953,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-test",
  "tracing",
@@ -2221,7 +2966,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2235,7 +2980,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
  "tracing",
 ]
@@ -2255,7 +3000,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "uuid",
  "whoami",
@@ -2270,7 +3015,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2291,9 +3036,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha1",
+ "sha1 0.11.0",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
  "tracing",
  "uuid",
@@ -2311,7 +3056,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2325,8 +3070,8 @@ dependencies = [
  "rez-next-version",
  "serde",
  "serde_json",
- "sha1",
- "thiserror",
+ "sha1 0.11.0",
+ "thiserror 2.0.18",
  "time",
  "tracing",
 ]
@@ -2358,7 +3103,7 @@ dependencies = [
  "rez-next-version",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -2373,7 +3118,7 @@ dependencies = [
  "rez-next-package",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
  "tracing",
 ]
@@ -2387,7 +3132,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "futures",
- "lru",
+ "lru 0.18.0",
  "memmap2",
  "num_cpus",
  "parking_lot",
@@ -2400,7 +3145,7 @@ dependencies = [
  "serde_yaml",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -2413,7 +3158,7 @@ dependencies = [
  "rez-next-common",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2440,7 +3185,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
  "tracing",
 ]
@@ -2460,7 +3205,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -2473,7 +3218,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2500,7 +3245,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2544,7 +3289,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2725,7 +3470,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2775,7 +3520,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2815,13 +3560,35 @@ dependencies = [
 
 [[package]]
 name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2831,8 +3598,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2840,6 +3607,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -2920,10 +3708,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2953,7 +3773,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2962,7 +3782,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2975,6 +3795,17 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2997,12 +3828,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.11.1",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2 0.10.9",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3013,7 +3927,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3024,7 +3938,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -3116,7 +4032,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3224,7 +4140,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -3267,7 +4183,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3356,6 +4272,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3437,6 +4370,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "atomic",
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
@@ -3460,6 +4394,15 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "walkdir"
@@ -3564,7 +4507,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3618,7 +4561,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3651,6 +4594,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -3718,7 +4733,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3729,7 +4744,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3965,7 +4980,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3981,7 +4996,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3993,7 +5008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -4030,6 +5045,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4048,7 +5082,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4069,7 +5103,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4089,7 +5123,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4098,6 +5132,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -4129,7 +5177,37 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
 ]
 
 [[package]]
@@ -4137,3 +5215,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,8 @@ tokio.workspace = true
 regex.workspace = true
 tempfile.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
+ratatui = "0.30.0"
+crossterm = "0.29.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/rez-next-build/Cargo.toml
+++ b/crates/rez-next-build/Cargo.toml
@@ -27,6 +27,9 @@ reqwest = { version = "0.13", features = ["stream"] }
 async-trait = "0.1"
 sha2 = "0.11"
 hex = "0.4"
+flate2 = "1.1"
+tar = "0.4"
+zip = "2.4"
 
 [features]
 git = ["dep:git2"]

--- a/crates/rez-next-build/src/builder.rs
+++ b/crates/rez-next-build/src/builder.rs
@@ -1,12 +1,13 @@
 //! Build manager and coordination
 
-use crate::{BuildArtifacts, BuildEnvironment, BuildProcess};
+use crate::{BuildArtifacts, BuildEnvironment, BuildEvent, BuildProcess};
 use rez_next_common::RezCoreError;
 use rez_next_context::ResolvedContext;
 use rez_next_package::Package;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use tokio::sync::mpsc;
 use uuid::Uuid;
 
 /// Build manager for coordinating package builds
@@ -39,6 +40,9 @@ pub struct BuildConfig {
     pub verbosity: BuildVerbosity,
     /// Environment variables to pass to build processes
     pub build_env_vars: HashMap<String, String>,
+    /// Optional live build event stream.
+    #[serde(skip)]
+    pub event_sender: Option<mpsc::UnboundedSender<BuildEvent>>,
 }
 
 /// Build verbosity levels
@@ -57,7 +61,7 @@ pub enum BuildVerbosity {
 impl Default for BuildConfig {
     fn default() -> Self {
         Self {
-            build_dir: PathBuf::from("build"),
+            build_dir: PathBuf::from(".rez_build"),
             temp_dir: PathBuf::from("tmp"),
             max_concurrent_builds: 4,
             build_timeout_seconds: 3600, // 1 hour
@@ -65,6 +69,7 @@ impl Default for BuildConfig {
             keep_artifacts: true,
             verbosity: BuildVerbosity::Normal,
             build_env_vars: HashMap::new(),
+            event_sender: None,
         }
     }
 }
@@ -327,6 +332,7 @@ impl BuildManager {
             request.install_path.as_ref(),
         )?;
         build_env.set_source_path(&request.source_dir);
+        Self::apply_build_env_overrides(&mut build_env, &request, &self.config);
 
         // Set variant-related environment variables if this is a variant build
         if let Some(variant_index) = request.variant_index {
@@ -343,11 +349,13 @@ impl BuildManager {
                     request.install_path.as_ref(),
                 )?;
                 build_env.set_source_path(&request.source_dir);
+                Self::apply_build_env_overrides(&mut build_env, &request, &self.config);
                 // Re-set variant env after recreating environment
                 build_env.set_variant_env(variant_index, &variant_requires);
                 build_env.set_variant_subpath(&variant_hash);
             }
         }
+        build_env.set_event_sender(self.config.event_sender.clone(), build_id.clone());
 
         // Create build process
         let mut build_process =
@@ -362,6 +370,20 @@ impl BuildManager {
         self.stats.builds_running += 1;
 
         Ok(build_id)
+    }
+
+    fn apply_build_env_overrides(
+        build_env: &mut BuildEnvironment,
+        request: &BuildRequest,
+        config: &BuildConfig,
+    ) {
+        for (key, value) in &config.build_env_vars {
+            build_env.add_env_var(key.clone(), value.clone());
+        }
+
+        for (key, value) in &request.options.env_vars {
+            build_env.add_env_var(key.clone(), value.clone());
+        }
     }
 
     /// Wait for a build to complete

--- a/crates/rez-next-build/src/environment.rs
+++ b/crates/rez-next-build/src/environment.rs
@@ -1,10 +1,12 @@
 //! Build environment management
 
+use crate::{BuildEvent, BuildEventKind, BuildStep};
 use rez_next_common::{RezCoreError, utils::get_thread_count};
 use rez_next_context::ResolvedContext;
 use rez_next_package::{Package, PackageRequirement};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use tokio::sync::mpsc;
 
 const DEFAULT_BUILD_VERSION: &str = "0.0.0";
 
@@ -23,6 +25,10 @@ pub struct BuildEnvironment {
     env_vars: HashMap<String, String>,
     /// Build context (resolved dependencies)
     context: Option<ResolvedContext>,
+    /// Optional live build event stream.
+    event_sender: Option<mpsc::UnboundedSender<BuildEvent>>,
+    /// Build ID used in live events.
+    event_build_id: Option<String>,
 }
 
 impl BuildEnvironment {
@@ -135,6 +141,8 @@ impl BuildEnvironment {
             temp_dir,
             env_vars,
             context: context.cloned(),
+            event_sender: None,
+            event_build_id: None,
         })
     }
 
@@ -166,6 +174,36 @@ impl BuildEnvironment {
     /// Get context
     pub fn get_context(&self) -> Option<&ResolvedContext> {
         self.context.as_ref()
+    }
+
+    /// Set the live build event sender.
+    pub fn set_event_sender(
+        &mut self,
+        sender: Option<mpsc::UnboundedSender<BuildEvent>>,
+        build_id: String,
+    ) {
+        self.event_sender = sender;
+        self.event_build_id = Some(build_id);
+    }
+
+    /// Emit a live build event for this build environment.
+    pub fn emit_event(&self, step: BuildStep, kind: BuildEventKind, message: String) {
+        let Some(sender) = &self.event_sender else {
+            return;
+        };
+        let timestamp_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_millis())
+            .unwrap_or_default();
+        let _ = sender.send(BuildEvent {
+            build_id: self.event_build_id.clone().unwrap_or_default(),
+            step: Some(step),
+            kind,
+            message,
+            success: None,
+            duration_ms: None,
+            timestamp_ms,
+        });
     }
 
     /// Add environment variable

--- a/crates/rez-next-build/src/lib.rs
+++ b/crates/rez-next-build/src/lib.rs
@@ -92,6 +92,10 @@ pub fn create_build_system(system_type: &str) -> Option<BuildSystem> {
         "python" => Some(BuildSystem::Python(systems::PythonBuildSystem::new())),
         "nodejs" => Some(BuildSystem::NodeJs(systems::NodeJsBuildSystem::new())),
         "cargo" => Some(BuildSystem::Cargo(systems::CargoBuildSystem::new())),
+        "binary_archive" => Some(BuildSystem::BinaryArchive(
+            systems::BinaryArchiveBuildSystem::new(),
+        )),
+        "pypi" | "pip" | "rez_pip" => Some(BuildSystem::Pypi(systems::PypiBuildSystem::new())),
         "custom" => Some(BuildSystem::Custom(systems::CustomBuildSystem::new(
             "default".to_string(),
         ))),

--- a/crates/rez-next-build/src/process.rs
+++ b/crates/rez-next-build/src/process.rs
@@ -8,7 +8,7 @@ use rez_next_common::RezCoreError;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::process::Child;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, mpsc};
 
 /// Build process for managing individual package builds
 #[derive(Debug)]
@@ -50,6 +50,42 @@ pub enum BuildStep {
     Installing,
     /// Cleaning up
     Cleanup,
+}
+
+/// Live build event kind.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum BuildEventKind {
+    /// Build process started.
+    BuildStarted,
+    /// One build step started.
+    StepStarted,
+    /// One line or chunk of step output.
+    StepOutput,
+    /// One line or chunk of step error output.
+    StepError,
+    /// One build step finished.
+    StepFinished,
+    /// Build process finished.
+    BuildFinished,
+}
+
+/// Live build event emitted while a build is running.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildEvent {
+    /// Build ID.
+    pub build_id: String,
+    /// Build step, if the event belongs to a step.
+    pub step: Option<BuildStep>,
+    /// Event kind.
+    pub kind: BuildEventKind,
+    /// Human-readable event message.
+    pub message: String,
+    /// Whether the event represents a successful result.
+    pub success: Option<bool>,
+    /// Event duration in milliseconds, when relevant.
+    pub duration_ms: Option<u64>,
+    /// Milliseconds since Unix epoch.
+    pub timestamp_ms: u128,
 }
 
 /// Build step result
@@ -212,7 +248,7 @@ impl BuildProcess {
 
     /// Run build steps
     async fn run_build_steps(
-        _build_id: &str,
+        build_id: &str,
         request: &BuildRequest,
         environment: &BuildEnvironment,
         config: &BuildConfig,
@@ -220,6 +256,25 @@ impl BuildProcess {
         errors: Arc<Mutex<String>>,
         child_process: Arc<Mutex<Option<Child>>>,
     ) -> Result<(), RezCoreError> {
+        let event_sender = config.event_sender.clone();
+        emit_build_event(
+            event_sender.as_ref(),
+            build_id,
+            None,
+            BuildEventKind::BuildStarted,
+            format!(
+                "Building {}",
+                request
+                    .package
+                    .version
+                    .as_ref()
+                    .map(|version| format!("{}-{}", request.package.name, version.as_str()))
+                    .unwrap_or_else(|| request.package.name.clone())
+            ),
+            None,
+            None,
+        );
+
         let steps = vec![
             BuildStep::Preparing,
             BuildStep::Configuring,
@@ -231,6 +286,16 @@ impl BuildProcess {
         ];
 
         for step in steps {
+            emit_build_event(
+                event_sender.as_ref(),
+                build_id,
+                Some(step.clone()),
+                BuildEventKind::StepStarted,
+                format!("{:?} started", step),
+                None,
+                None,
+            );
+
             let step_result = Self::execute_build_step(
                 &step,
                 request,
@@ -239,6 +304,14 @@ impl BuildProcess {
                 child_process.clone(),
             )
             .await?;
+
+            emit_step_lines(
+                event_sender.as_ref(),
+                build_id,
+                &step,
+                BuildEventKind::StepOutput,
+                &step_result.output,
+            );
 
             // Append output
             {
@@ -250,20 +323,57 @@ impl BuildProcess {
 
             // Append errors if any
             if !step_result.errors.is_empty() {
+                emit_step_lines(
+                    event_sender.as_ref(),
+                    build_id,
+                    &step,
+                    BuildEventKind::StepError,
+                    &step_result.errors,
+                );
+
                 let mut errors_guard = errors.lock().await;
                 errors_guard.push_str(&format!("=== {:?} Errors ===\n", step));
                 errors_guard.push_str(&step_result.errors);
                 errors_guard.push('\n');
             }
 
+            emit_build_event(
+                event_sender.as_ref(),
+                build_id,
+                Some(step.clone()),
+                BuildEventKind::StepFinished,
+                format!("{:?} finished", step),
+                Some(step_result.success),
+                Some(step_result.duration_ms),
+            );
+
             // Stop on failure
             if !step_result.success {
+                emit_build_event(
+                    event_sender.as_ref(),
+                    build_id,
+                    None,
+                    BuildEventKind::BuildFinished,
+                    format!("Build failed during {:?}", step),
+                    Some(false),
+                    None,
+                );
                 return Err(RezCoreError::BuildError(format!(
                     "Build step {:?} failed: {}",
                     step, step_result.errors
                 )));
             }
         }
+
+        emit_build_event(
+            event_sender.as_ref(),
+            build_id,
+            None,
+            BuildEventKind::BuildFinished,
+            "Build finished".to_string(),
+            Some(true),
+            None,
+        );
 
         Ok(())
     }
@@ -443,4 +553,52 @@ impl BuildProcess {
 
         Ok((true, "Cleanup completed".to_string(), String::new()))
     }
+}
+
+fn emit_step_lines(
+    sender: Option<&mpsc::UnboundedSender<BuildEvent>>,
+    build_id: &str,
+    step: &BuildStep,
+    kind: BuildEventKind,
+    text: &str,
+) {
+    for line in text.lines().filter(|line| !line.trim().is_empty()) {
+        emit_build_event(
+            sender,
+            build_id,
+            Some(step.clone()),
+            kind.clone(),
+            line.trim().to_string(),
+            None,
+            None,
+        );
+    }
+}
+
+fn emit_build_event(
+    sender: Option<&mpsc::UnboundedSender<BuildEvent>>,
+    build_id: &str,
+    step: Option<BuildStep>,
+    kind: BuildEventKind,
+    message: String,
+    success: Option<bool>,
+    duration_ms: Option<u64>,
+) {
+    let Some(sender) = sender else {
+        return;
+    };
+
+    let timestamp_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default();
+    let _ = sender.send(BuildEvent {
+        build_id: build_id.to_string(),
+        step,
+        kind,
+        message,
+        success,
+        duration_ms,
+        timestamp_ms,
+    });
 }

--- a/crates/rez-next-build/src/systems/binary_archive.rs
+++ b/crates/rez-next-build/src/systems/binary_archive.rs
@@ -1,0 +1,349 @@
+//! Built-in binary archive build plugin.
+//!
+//! This covers the common Rez pattern: obtain a prebuilt archive, verify it,
+//! extract it, optionally strip a payload prefix, and copy the payload into the
+//! package install root.
+
+use crate::{BuildEnvironment, BuildRequest, BuildStep, BuildStepResult};
+use flate2::read::GzDecoder;
+use rez_next_common::RezCoreError;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tar::Archive;
+use tokio::process::Child;
+use tokio::sync::Mutex;
+
+const ARTIFACT_ENV: &str = "REZ_BINARY_ARCHIVE_ARTIFACT";
+const URL_ENV: &str = "REZ_BINARY_ARCHIVE_URL";
+const SHA256_ENV: &str = "REZ_BINARY_ARCHIVE_SHA256";
+const PAYLOAD_PREFIX_ENV: &str = "REZ_BINARY_ARCHIVE_PAYLOAD_PREFIX";
+
+/// Native build system for prebuilt binary archives.
+#[derive(Debug, Clone)]
+pub struct BinaryArchiveBuildSystem;
+
+impl BinaryArchiveBuildSystem {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn configure(
+        &self,
+        _request: &BuildRequest,
+        _environment: &BuildEnvironment,
+    ) -> Result<BuildStepResult, RezCoreError> {
+        Ok(step_ok(
+            BuildStep::Configuring,
+            "binary_archive plugin configured",
+        ))
+    }
+
+    pub async fn compile(
+        &self,
+        _request: &BuildRequest,
+        _environment: &BuildEnvironment,
+        _child_process: Arc<Mutex<Option<Child>>>,
+    ) -> Result<BuildStepResult, RezCoreError> {
+        Ok(step_ok(
+            BuildStep::Compiling,
+            "binary_archive uses prebuilt artifacts",
+        ))
+    }
+
+    pub async fn test(
+        &self,
+        _request: &BuildRequest,
+        _environment: &BuildEnvironment,
+        _child_process: Arc<Mutex<Option<Child>>>,
+    ) -> Result<BuildStepResult, RezCoreError> {
+        Ok(step_ok(BuildStep::Testing, "binary_archive tests skipped"))
+    }
+
+    pub async fn package(
+        &self,
+        _request: &BuildRequest,
+        _environment: &BuildEnvironment,
+    ) -> Result<BuildStepResult, RezCoreError> {
+        Ok(step_ok(
+            BuildStep::Packaging,
+            "binary_archive package step completed",
+        ))
+    }
+
+    pub async fn install(
+        &self,
+        _request: &BuildRequest,
+        environment: &BuildEnvironment,
+    ) -> Result<BuildStepResult, RezCoreError> {
+        match self.install_archive(environment).await {
+            Ok(output) => Ok(BuildStepResult {
+                step: BuildStep::Installing,
+                success: true,
+                output,
+                errors: String::new(),
+                duration_ms: 0,
+            }),
+            Err(err) => Ok(BuildStepResult {
+                step: BuildStep::Installing,
+                success: false,
+                output: String::new(),
+                errors: err.to_string(),
+                duration_ms: 0,
+            }),
+        }
+    }
+
+    async fn install_archive(
+        &self,
+        environment: &BuildEnvironment,
+    ) -> Result<String, RezCoreError> {
+        let env = environment.get_env_vars();
+        let work_dir = environment.get_temp_dir().join("binary_archive");
+        let extract_dir = work_dir.join("extract");
+        let install_dir = environment.get_install_dir();
+
+        tokio::fs::create_dir_all(&work_dir).await.map_err(|err| {
+            RezCoreError::BuildError(format!("Failed to create archive work dir: {err}"))
+        })?;
+        tokio::fs::create_dir_all(&extract_dir)
+            .await
+            .map_err(|err| {
+                RezCoreError::BuildError(format!("Failed to create archive extract dir: {err}"))
+            })?;
+        tokio::fs::create_dir_all(install_dir)
+            .await
+            .map_err(|err| {
+                RezCoreError::BuildError(format!("Failed to create install dir: {err}"))
+            })?;
+
+        let artifact = self.resolve_artifact(env, &work_dir).await?;
+        if let Some(expected_sha256) = env.get(SHA256_ENV).filter(|value| !value.is_empty()) {
+            verify_sha256(&artifact, expected_sha256)?;
+        }
+
+        extract_archive(&artifact, &extract_dir)?;
+        let payload = env
+            .get(PAYLOAD_PREFIX_ENV)
+            .filter(|value| !value.is_empty())
+            .map_or(extract_dir.clone(), |prefix| extract_dir.join(prefix));
+
+        if !payload.is_dir() {
+            return Err(RezCoreError::BuildError(format!(
+                "binary archive payload directory does not exist: {}",
+                payload.display()
+            )));
+        }
+
+        copy_tree_contents(&payload, install_dir)?;
+
+        Ok(format!(
+            "Installed binary archive {} to {}",
+            artifact.display(),
+            install_dir.display()
+        ))
+    }
+
+    async fn resolve_artifact(
+        &self,
+        env: &std::collections::HashMap<String, String>,
+        work_dir: &Path,
+    ) -> Result<PathBuf, RezCoreError> {
+        if let Some(path) = env.get(ARTIFACT_ENV).filter(|value| !value.is_empty()) {
+            let artifact = PathBuf::from(path);
+            if artifact.is_file() {
+                return Ok(artifact);
+            }
+            return Err(RezCoreError::BuildError(format!(
+                "binary archive artifact does not exist: {}",
+                artifact.display()
+            )));
+        }
+
+        let url = env
+            .get(URL_ENV)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                RezCoreError::BuildError(format!(
+                    "binary_archive requires {ARTIFACT_ENV} or {URL_ENV}"
+                ))
+            })?;
+        let filename = url
+            .rsplit('/')
+            .next()
+            .filter(|name| !name.is_empty())
+            .unwrap_or("artifact.bin");
+        let destination = work_dir.join(filename);
+
+        let response = reqwest::get(url).await.map_err(|err| {
+            RezCoreError::BuildError(format!("Failed to download binary archive {url}: {err}"))
+        })?;
+        let bytes = response.bytes().await.map_err(|err| {
+            RezCoreError::BuildError(format!("Failed to read binary archive response: {err}"))
+        })?;
+        tokio::fs::write(&destination, bytes).await.map_err(|err| {
+            RezCoreError::BuildError(format!("Failed to write downloaded archive: {err}"))
+        })?;
+
+        Ok(destination)
+    }
+}
+
+impl Default for BinaryArchiveBuildSystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn step_ok(step: BuildStep, output: &str) -> BuildStepResult {
+    BuildStepResult {
+        step,
+        success: true,
+        output: output.to_string(),
+        errors: String::new(),
+        duration_ms: 0,
+    }
+}
+
+fn verify_sha256(path: &Path, expected_sha256: &str) -> Result<(), RezCoreError> {
+    let mut file = fs::File::open(path).map_err(|err| {
+        RezCoreError::BuildError(format!("Failed to open archive for sha256: {err}"))
+    })?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 1024 * 1024];
+    loop {
+        let bytes_read = file.read(&mut buffer).map_err(|err| {
+            RezCoreError::BuildError(format!("Failed to read archive for sha256: {err}"))
+        })?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+    let actual = hex::encode(hasher.finalize());
+    if actual != expected_sha256 {
+        return Err(RezCoreError::BuildError(format!(
+            "binary archive sha256 mismatch: expected {expected_sha256}, got {actual}"
+        )));
+    }
+    Ok(())
+}
+
+fn extract_archive(artifact: &Path, destination: &Path) -> Result<(), RezCoreError> {
+    let name = artifact
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    if name.ends_with(".zip") {
+        extract_zip(artifact, destination)
+    } else if name.ends_with(".tar.gz") || name.ends_with(".tgz") {
+        extract_tar_gz(artifact, destination)
+    } else {
+        Err(RezCoreError::BuildError(format!(
+            "unsupported binary archive format: {}",
+            artifact.display()
+        )))
+    }
+}
+
+fn extract_zip(artifact: &Path, destination: &Path) -> Result<(), RezCoreError> {
+    let file = fs::File::open(artifact)
+        .map_err(|err| RezCoreError::BuildError(format!("Failed to open zip archive: {err}")))?;
+    let mut archive = zip::ZipArchive::new(file)
+        .map_err(|err| RezCoreError::BuildError(format!("Failed to read zip archive: {err}")))?;
+
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index).map_err(|err| {
+            RezCoreError::BuildError(format!("Failed to read zip entry {index}: {err}"))
+        })?;
+        let Some(enclosed) = entry.enclosed_name() else {
+            continue;
+        };
+        let target = destination.join(enclosed);
+        if entry.is_dir() {
+            fs::create_dir_all(&target).map_err(|err| {
+                RezCoreError::BuildError(format!("Failed to create zip dir: {err}"))
+            })?;
+        } else {
+            if let Some(parent) = target.parent() {
+                fs::create_dir_all(parent).map_err(|err| {
+                    RezCoreError::BuildError(format!("Failed to create zip parent dir: {err}"))
+                })?;
+            }
+            let mut out = fs::File::create(&target).map_err(|err| {
+                RezCoreError::BuildError(format!("Failed to create zip output file: {err}"))
+            })?;
+            std::io::copy(&mut entry, &mut out).map_err(|err| {
+                RezCoreError::BuildError(format!("Failed to extract zip entry: {err}"))
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+fn extract_tar_gz(artifact: &Path, destination: &Path) -> Result<(), RezCoreError> {
+    let file = fs::File::open(artifact)
+        .map_err(|err| RezCoreError::BuildError(format!("Failed to open tar.gz archive: {err}")))?;
+    let decoder = GzDecoder::new(file);
+    let mut archive = Archive::new(decoder);
+    archive
+        .unpack(destination)
+        .map_err(|err| RezCoreError::BuildError(format!("Failed to unpack tar.gz archive: {err}")))
+}
+
+fn copy_tree_contents(source: &Path, destination: &Path) -> Result<(), RezCoreError> {
+    fs::create_dir_all(destination)
+        .map_err(|err| RezCoreError::BuildError(format!("Failed to create directory: {err}")))?;
+    for entry in fs::read_dir(source)
+        .map_err(|err| RezCoreError::BuildError(format!("Failed to read directory: {err}")))?
+    {
+        let entry = entry
+            .map_err(|err| RezCoreError::BuildError(format!("Failed to read entry: {err}")))?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if source_path.is_dir() {
+            if destination_path.exists() {
+                fs::remove_dir_all(&destination_path).map_err(|err| {
+                    RezCoreError::BuildError(format!("Failed to remove directory: {err}"))
+                })?;
+            }
+            copy_dir_recursive(&source_path, &destination_path)?;
+        } else {
+            if let Some(parent) = destination_path.parent() {
+                fs::create_dir_all(parent).map_err(|err| {
+                    RezCoreError::BuildError(format!("Failed to create parent directory: {err}"))
+                })?;
+            }
+            fs::copy(&source_path, &destination_path).map_err(|err| {
+                RezCoreError::BuildError(format!("Failed to copy archive file: {err}"))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<(), RezCoreError> {
+    fs::create_dir_all(destination)
+        .map_err(|err| RezCoreError::BuildError(format!("Failed to create directory: {err}")))?;
+    for entry in fs::read_dir(source)
+        .map_err(|err| RezCoreError::BuildError(format!("Failed to read directory: {err}")))?
+    {
+        let entry = entry
+            .map_err(|err| RezCoreError::BuildError(format!("Failed to read entry: {err}")))?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if source_path.is_dir() {
+            copy_dir_recursive(&source_path, &destination_path)?;
+        } else {
+            fs::copy(&source_path, &destination_path).map_err(|err| {
+                RezCoreError::BuildError(format!("Failed to copy archive file: {err}"))
+            })?;
+        }
+    }
+    Ok(())
+}

--- a/crates/rez-next-build/src/systems/custom.rs
+++ b/crates/rez-next-build/src/systems/custom.rs
@@ -1,10 +1,13 @@
 //! Custom build system implementation
 
-use crate::{BuildEnvironment, BuildRequest, BuildStep, BuildStepResult};
+use crate::{BuildEnvironment, BuildEventKind, BuildRequest, BuildStep, BuildStepResult};
 use rez_next_common::RezCoreError;
 use rez_next_context::ShellExecutor;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::sync::Arc;
+use std::time::Instant;
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::process::Child;
 use tokio::sync::Mutex;
 
@@ -35,10 +38,19 @@ impl CustomBuildSystem {
 
     pub async fn compile(
         &self,
-        _request: &BuildRequest,
-        _environment: &BuildEnvironment,
+        request: &BuildRequest,
+        environment: &BuildEnvironment,
         _child_process: Arc<Mutex<Option<Child>>>,
     ) -> Result<BuildStepResult, RezCoreError> {
+        match self.script_name.as_str() {
+            "default" | "copy-only" | "build_command" => {}
+            _ => {
+                return self
+                    .execute_build_script(request, environment, "build")
+                    .await;
+            }
+        }
+
         Ok(BuildStepResult {
             step: BuildStep::Compiling,
             success: true,
@@ -146,7 +158,7 @@ impl CustomBuildSystem {
         })?;
 
         let executor = ShellExecutor::with_shell(rez_next_context::ShellType::detect())
-            .with_environment(environment.get_env_vars().clone())
+            .with_environment(Self::script_env(environment))
             .with_working_directory(request.source_dir.clone());
 
         let expanded_command =
@@ -231,27 +243,245 @@ impl CustomBuildSystem {
             RezCoreError::BuildError(format!("Failed to create install directory: {}", e))
         })?;
 
-        let executor = ShellExecutor::with_shell(rez_next_context::ShellType::detect())
-            .with_environment(environment.get_env_vars().clone())
-            .with_working_directory(request.source_dir.clone());
-
         let exec_command = if self.script_name.ends_with(".py") {
-            format!("python {} {}", script_path.to_string_lossy(), command)
+            return Self::execute_python_build_script(request, environment, &script_path, command)
+                .await;
         } else if self.script_name.ends_with(".sh") {
             format!("bash {} {}", script_path.to_string_lossy(), command)
         } else {
             format!("{} {}", script_path.to_string_lossy(), command)
         };
 
+        let executor = ShellExecutor::with_shell(rez_next_context::ShellType::detect())
+            .with_environment(Self::script_env(environment))
+            .with_working_directory(request.source_dir.clone());
         let result = executor.execute(&exec_command).await?;
+        let success = result.is_success();
+        let output = format!(
+            "Invoking custom build system...\nRunning build command: {}\n{}",
+            exec_command, result.stdout
+        );
+
+        let errors = if success {
+            result.stderr.clone()
+        } else {
+            Self::format_command_failure(&exec_command, &result)
+        };
 
         Ok(BuildStepResult {
             step: BuildStep::Installing,
-            success: result.is_success(),
-            output: result.stdout,
-            errors: result.stderr,
+            success,
+            output,
+            errors,
             duration_ms: result.execution_time_ms,
         })
+    }
+
+    async fn execute_python_build_script(
+        request: &BuildRequest,
+        environment: &BuildEnvironment,
+        script_path: &Path,
+        command: &str,
+    ) -> Result<BuildStepResult, RezCoreError> {
+        let python = Self::find_host_python()?;
+        let started_at = Instant::now();
+        let mut process = tokio::process::Command::new(&python);
+        process
+            .arg(script_path)
+            .arg(command)
+            .env_clear()
+            .envs(Self::script_env(environment))
+            .current_dir(&request.source_dir)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let exec_command = format!("{} {} {}", python.display(), script_path.display(), command);
+        environment.emit_event(
+            step_for_script_command(command),
+            BuildEventKind::StepOutput,
+            "Invoking custom build system...".to_string(),
+        );
+        environment.emit_event(
+            step_for_script_command(command),
+            BuildEventKind::StepOutput,
+            format!("Running build command: {}", exec_command),
+        );
+
+        let mut child = process.spawn().map_err(|err| {
+            RezCoreError::ExecutionError(format!(
+                "Failed to run Python build script with {}: {}",
+                python.display(),
+                err
+            ))
+        })?;
+
+        let step = step_for_script_command(command);
+        let stdout_task = child.stdout.take().map(|stdout| {
+            tokio::spawn(read_script_stream(
+                stdout,
+                environment.clone(),
+                step.clone(),
+                BuildEventKind::StepOutput,
+            ))
+        });
+        let stderr_task = child.stderr.take().map(|stderr| {
+            tokio::spawn(read_script_stream(
+                stderr,
+                environment.clone(),
+                step.clone(),
+                BuildEventKind::StepError,
+            ))
+        });
+        let status = child.wait().await.map_err(|err| {
+            RezCoreError::ExecutionError(format!(
+                "Failed to wait for Python build script with {}: {}",
+                python.display(),
+                err
+            ))
+        })?;
+
+        let raw_stdout = match stdout_task {
+            Some(task) => task.await.unwrap_or_default(),
+            None => String::new(),
+        };
+        let stderr = match stderr_task {
+            Some(task) => task.await.unwrap_or_default(),
+            None => String::new(),
+        };
+        let success = status.success();
+        let exit_code = status.code().unwrap_or(-1);
+        let stdout = format!(
+            "Invoking custom build system...\nRunning build command: {}\n{}",
+            exec_command, raw_stdout
+        );
+
+        let errors = if success {
+            stderr
+        } else {
+            Self::format_raw_command_failure(&exec_command, exit_code, &raw_stdout, &stderr)
+        };
+
+        Ok(BuildStepResult {
+            step: BuildStep::Installing,
+            success,
+            output: stdout,
+            errors,
+            duration_ms: started_at.elapsed().as_millis() as u64,
+        })
+    }
+
+    fn find_host_python() -> Result<PathBuf, RezCoreError> {
+        if let Ok(path) =
+            std::env::var("REZ_NEXT_BUILD_PYTHON").or_else(|_| std::env::var("PYTHON"))
+        {
+            let path = PathBuf::from(path);
+            if path.is_file() {
+                return Ok(path);
+            }
+        }
+
+        let candidates: &[&str] = if cfg!(windows) {
+            &["python", "py"]
+        } else {
+            &["python3", "python"]
+        };
+        for candidate in candidates {
+            let mut command = std::process::Command::new(candidate);
+            if *candidate == "py" {
+                command.arg("-3");
+            }
+            let output = command
+                .args(["-c", "import sys; print(sys.executable)"])
+                .output();
+            if let Ok(output) = output {
+                if output.status.success() {
+                    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                    if !path.is_empty() {
+                        return Ok(PathBuf::from(path));
+                    }
+                }
+            }
+        }
+
+        Err(RezCoreError::ExecutionError(
+            "No host Python found for rezbuild.py. Set REZ_NEXT_BUILD_PYTHON to a Python executable."
+                .to_string(),
+        ))
+    }
+
+    fn format_command_failure(command: &str, result: &rez_next_context::CommandResult) -> String {
+        Self::format_raw_command_failure(command, result.exit_code, &result.stdout, &result.stderr)
+    }
+
+    fn format_raw_command_failure(
+        command: &str,
+        exit_code: i32,
+        stdout: &str,
+        stderr: &str,
+    ) -> String {
+        let mut message = format!("Command failed with exit code {}: {}", exit_code, command);
+
+        if !stderr.trim().is_empty() {
+            message.push_str("\nstderr:\n");
+            message.push_str(stderr.trim_end());
+        }
+
+        if !stdout.trim().is_empty() {
+            message.push_str("\nstdout:\n");
+            message.push_str(stdout.trim_end());
+        }
+
+        message
+    }
+
+    fn script_env(environment: &BuildEnvironment) -> std::collections::HashMap<String, String> {
+        let mut env = environment.get_env_vars().clone();
+        Self::add_rez_next_pythonpath(&mut env);
+        Self::add_windows_runtime_env(&mut env);
+        env
+    }
+
+    fn add_rez_next_pythonpath(env: &mut std::collections::HashMap<String, String>) {
+        let mut paths = Vec::new();
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let workspace_root = manifest_dir
+            .parent()
+            .and_then(|path| path.parent())
+            .map(Path::to_path_buf)
+            .unwrap_or(manifest_dir);
+
+        for candidate in [
+            workspace_root.join("crates/rez-next-python/python"),
+            workspace_root.join("python"),
+        ] {
+            if candidate.is_dir() {
+                paths.push(candidate.to_string_lossy().to_string());
+            }
+        }
+
+        if paths.is_empty() {
+            return;
+        }
+
+        let separator = if cfg!(windows) { ";" } else { ":" };
+        if let Some(existing) = env.get("PYTHONPATH").filter(|value| !value.is_empty()) {
+            paths.push(existing.clone());
+        }
+        env.insert("PYTHONPATH".to_string(), paths.join(separator));
+    }
+
+    fn add_windows_runtime_env(env: &mut std::collections::HashMap<String, String>) {
+        if !cfg!(windows) {
+            return;
+        }
+
+        for key in ["SystemRoot", "WINDIR", "TEMP", "TMP"] {
+            if !env.contains_key(key) {
+                if let Ok(value) = std::env::var(key) {
+                    env.insert(key.to_string(), value);
+                }
+            }
+        }
     }
 
     /// Copy package files from source to install directory
@@ -352,6 +582,46 @@ impl CustomBuildSystem {
             || file_name.ends_with(".pyo")
             || file_name.ends_with(".log")
     }
+}
+
+fn step_for_script_command(command: &str) -> BuildStep {
+    match command {
+        "build" => BuildStep::Compiling,
+        "install" => BuildStep::Installing,
+        "test" => BuildStep::Testing,
+        _ => BuildStep::Installing,
+    }
+}
+
+async fn read_script_stream<R>(
+    reader: R,
+    environment: BuildEnvironment,
+    step: BuildStep,
+    kind: BuildEventKind,
+) -> String
+where
+    R: AsyncRead + Unpin,
+{
+    let mut lines = BufReader::new(reader).lines();
+    let mut output = String::new();
+    loop {
+        match lines.next_line().await {
+            Ok(Some(line)) => {
+                environment.emit_event(step.clone(), kind.clone(), line.clone());
+                output.push_str(&line);
+                output.push('\n');
+            }
+            Ok(None) => break,
+            Err(err) => {
+                let message = format!("Failed to read build output: {}", err);
+                environment.emit_event(step.clone(), BuildEventKind::StepError, message.clone());
+                output.push_str(&message);
+                output.push('\n');
+                break;
+            }
+        }
+    }
+    output
 }
 
 #[cfg(test)]

--- a/crates/rez-next-build/src/systems/mod.rs
+++ b/crates/rez-next-build/src/systems/mod.rs
@@ -6,22 +6,28 @@
 //! - `python`      — Python setuptools / rezbuild.py
 //! - `nodejs`      — Node.js npm
 //! - `cargo_build` — Rust Cargo
+//! - `binary_archive` — Prebuilt archive download / extract / install
+//! - `pypi`        — pip-compatible Python package install
 //! - `custom`      — Custom build scripts / copy-only
 //! - `cmd_builder` — Shared command-runner helpers (no shell-specific strings)
 
+mod binary_archive;
 mod cargo_build;
 mod cmake;
 pub(crate) mod cmd_builder;
 mod custom;
 mod make;
 mod nodejs;
+mod pypi;
 mod python;
 
+pub use binary_archive::BinaryArchiveBuildSystem;
 pub use cargo_build::CargoBuildSystem;
 pub use cmake::CMakeBuildSystem;
 pub use custom::CustomBuildSystem;
 pub use make::MakeBuildSystem;
 pub use nodejs::NodeJsBuildSystem;
+pub use pypi::PypiBuildSystem;
 pub use python::PythonBuildSystem;
 
 use crate::{BuildEnvironment, BuildRequest, BuildStepResult};
@@ -45,6 +51,10 @@ pub enum BuildSystemType {
     NodeJs,
     /// Rust Cargo
     Cargo,
+    /// Prebuilt binary archive
+    BinaryArchive,
+    /// pip-compatible Python package
+    Pypi,
     /// Custom build script
     Custom,
     /// Unknown/unsupported
@@ -60,6 +70,8 @@ impl BuildSystemType {
             BuildSystemType::Python => "python",
             BuildSystemType::NodeJs => "nodejs",
             BuildSystemType::Cargo => "cargo",
+            BuildSystemType::BinaryArchive => "binary_archive",
+            BuildSystemType::Pypi => "pypi",
             BuildSystemType::Custom => "custom",
             BuildSystemType::Unknown => "unknown",
         }
@@ -68,7 +80,16 @@ impl BuildSystemType {
 
 /// Get all creatable build system types (excluding Unknown)
 pub fn get_buildsys_types() -> Vec<&'static str> {
-    vec!["cmake", "make", "python", "nodejs", "cargo", "custom"]
+    vec![
+        "cmake",
+        "make",
+        "python",
+        "nodejs",
+        "cargo",
+        "binary_archive",
+        "pypi",
+        "custom",
+    ]
 }
 
 /// Build system abstraction
@@ -84,6 +105,10 @@ pub enum BuildSystem {
     NodeJs(NodeJsBuildSystem),
     /// Rust Cargo build system
     Cargo(CargoBuildSystem),
+    /// Prebuilt binary archive build system
+    BinaryArchive(BinaryArchiveBuildSystem),
+    /// PyPI package build system
+    Pypi(PypiBuildSystem),
     /// Custom build system
     Custom(CustomBuildSystem),
 }
@@ -150,6 +175,12 @@ impl BuildSystem {
                 "python" => return Ok(BuildSystem::Python(PythonBuildSystem::new())),
                 "nodejs" => return Ok(BuildSystem::NodeJs(NodeJsBuildSystem::new())),
                 "cargo" => return Ok(BuildSystem::Cargo(CargoBuildSystem::new())),
+                "binary_archive" => {
+                    return Ok(BuildSystem::BinaryArchive(BinaryArchiveBuildSystem::new()));
+                }
+                "pypi" | "pip" | "rez_pip" => {
+                    return Ok(BuildSystem::Pypi(PypiBuildSystem::new()));
+                }
                 _ => {
                     return Ok(BuildSystem::Custom(CustomBuildSystem::new(
                         build_system.clone(),
@@ -179,6 +210,8 @@ impl BuildSystem {
             BuildSystem::Python(python) => python.configure(request, environment).await,
             BuildSystem::NodeJs(nodejs) => nodejs.configure(request, environment).await,
             BuildSystem::Cargo(cargo) => cargo.configure(request, environment).await,
+            BuildSystem::BinaryArchive(binary) => binary.configure(request, environment).await,
+            BuildSystem::Pypi(pypi) => pypi.configure(request, environment).await,
             BuildSystem::Custom(custom) => custom.configure(request, environment).await,
         }
     }
@@ -200,6 +233,10 @@ impl BuildSystem {
                 nodejs.compile(request, environment, child_process).await
             }
             BuildSystem::Cargo(cargo) => cargo.compile(request, environment, child_process).await,
+            BuildSystem::BinaryArchive(binary) => {
+                binary.compile(request, environment, child_process).await
+            }
+            BuildSystem::Pypi(pypi) => pypi.compile(request, environment, child_process).await,
             BuildSystem::Custom(custom) => {
                 custom.compile(request, environment, child_process).await
             }
@@ -219,6 +256,10 @@ impl BuildSystem {
             BuildSystem::Python(python) => python.test(request, environment, child_process).await,
             BuildSystem::NodeJs(nodejs) => nodejs.test(request, environment, child_process).await,
             BuildSystem::Cargo(cargo) => cargo.test(request, environment, child_process).await,
+            BuildSystem::BinaryArchive(binary) => {
+                binary.test(request, environment, child_process).await
+            }
+            BuildSystem::Pypi(pypi) => pypi.test(request, environment, child_process).await,
             BuildSystem::Custom(custom) => custom.test(request, environment, child_process).await,
         }
     }
@@ -235,6 +276,8 @@ impl BuildSystem {
             BuildSystem::Python(python) => python.package(request, environment).await,
             BuildSystem::NodeJs(nodejs) => nodejs.package(request, environment).await,
             BuildSystem::Cargo(cargo) => cargo.package(request, environment).await,
+            BuildSystem::BinaryArchive(binary) => binary.package(request, environment).await,
+            BuildSystem::Pypi(pypi) => pypi.package(request, environment).await,
             BuildSystem::Custom(custom) => custom.package(request, environment).await,
         }
     }
@@ -251,6 +294,8 @@ impl BuildSystem {
             BuildSystem::Python(python) => python.install(request, environment).await,
             BuildSystem::NodeJs(nodejs) => nodejs.install(request, environment).await,
             BuildSystem::Cargo(cargo) => cargo.install(request, environment).await,
+            BuildSystem::BinaryArchive(binary) => binary.install(request, environment).await,
+            BuildSystem::Pypi(pypi) => pypi.install(request, environment).await,
             BuildSystem::Custom(custom) => custom.install(request, environment).await,
         }
     }

--- a/crates/rez-next-build/src/systems/pypi.rs
+++ b/crates/rez-next-build/src/systems/pypi.rs
@@ -1,0 +1,205 @@
+//! Built-in PyPI package build plugin.
+//!
+//! This covers the common rez-pip style workflow for a single package: install
+//! a pip-compatible artifact or spec into the Rez package install root.
+
+use crate::{BuildEnvironment, BuildRequest, BuildStep, BuildStepResult};
+use rez_next_common::RezCoreError;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::process::Child;
+use tokio::sync::Mutex;
+
+const PACKAGE_ENV: &str = "REZ_PYPI_PACKAGE";
+const REQUIREMENT_ENV: &str = "REZ_PYPI_REQUIREMENT";
+const EXTRA_ARGS_ENV: &str = "REZ_PYPI_EXTRA_ARGS";
+const WITH_DEPS_ENV: &str = "REZ_PYPI_WITH_DEPS";
+
+/// Native build system for pip-compatible Python packages.
+#[derive(Debug, Clone, Default)]
+pub struct PypiBuildSystem;
+
+impl PypiBuildSystem {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn configure(
+        &self,
+        _request: &BuildRequest,
+        environment: &BuildEnvironment,
+    ) -> Result<BuildStepResult, RezCoreError> {
+        run_python(
+            environment,
+            None,
+            BuildStep::Configuring,
+            &["-m".to_string(), "pip".to_string(), "--version".to_string()],
+        )
+        .await
+    }
+
+    pub async fn compile(
+        &self,
+        _request: &BuildRequest,
+        _environment: &BuildEnvironment,
+        _child_process: Arc<Mutex<Option<Child>>>,
+    ) -> Result<BuildStepResult, RezCoreError> {
+        Ok(step_ok(
+            BuildStep::Compiling,
+            "pypi uses pip install artifacts",
+        ))
+    }
+
+    pub async fn test(
+        &self,
+        _request: &BuildRequest,
+        _environment: &BuildEnvironment,
+        _child_process: Arc<Mutex<Option<Child>>>,
+    ) -> Result<BuildStepResult, RezCoreError> {
+        Ok(step_ok(BuildStep::Testing, "pypi plugin tests skipped"))
+    }
+
+    pub async fn package(
+        &self,
+        _request: &BuildRequest,
+        _environment: &BuildEnvironment,
+    ) -> Result<BuildStepResult, RezCoreError> {
+        Ok(step_ok(BuildStep::Packaging, "pypi package step completed"))
+    }
+
+    pub async fn install(
+        &self,
+        request: &BuildRequest,
+        environment: &BuildEnvironment,
+    ) -> Result<BuildStepResult, RezCoreError> {
+        let install_dir = environment.get_install_dir();
+        let python_dir = install_dir.join("python");
+        tokio::fs::create_dir_all(&python_dir)
+            .await
+            .map_err(|err| {
+                RezCoreError::BuildError(format!("Failed to create pypi install dir: {err}"))
+            })?;
+
+        let env = environment.get_env_vars();
+        let package_spec = env
+            .get(PACKAGE_ENV)
+            .filter(|value| !value.is_empty())
+            .cloned()
+            .or_else(|| default_package_spec(request));
+        let requirement = env.get(REQUIREMENT_ENV).filter(|value| !value.is_empty());
+
+        if package_spec.is_none() && requirement.is_none() {
+            return Ok(BuildStepResult {
+                step: BuildStep::Installing,
+                success: false,
+                output: String::new(),
+                errors: format!("pypi requires {PACKAGE_ENV} or {REQUIREMENT_ENV}"),
+                duration_ms: 0,
+            });
+        }
+
+        let mut args = vec![
+            "-m".to_string(),
+            "pip".to_string(),
+            "install".to_string(),
+            "--disable-pip-version-check".to_string(),
+            "--target".to_string(),
+            python_dir.to_string_lossy().to_string(),
+        ];
+
+        if !env_var_truthy(env.get(WITH_DEPS_ENV)) {
+            args.push("--no-deps".to_string());
+        }
+
+        if let Some(extra_args) = env.get(EXTRA_ARGS_ENV).filter(|value| !value.is_empty()) {
+            args.extend(extra_args.split_whitespace().map(ToString::to_string));
+        }
+
+        if let Some(requirement) = requirement {
+            args.push("-r".to_string());
+            args.push(requirement.clone());
+        }
+
+        if let Some(package_spec) = package_spec {
+            args.push(package_spec);
+        }
+
+        run_python(
+            environment,
+            Some(&request.source_dir),
+            BuildStep::Installing,
+            &args,
+        )
+        .await
+    }
+}
+
+fn default_package_spec(request: &BuildRequest) -> Option<String> {
+    request
+        .package
+        .version
+        .as_ref()
+        .map(|version| format!("{}=={}", request.package.name, version.as_str()))
+}
+
+async fn run_python(
+    environment: &BuildEnvironment,
+    cwd: Option<&Path>,
+    step: BuildStep,
+    args: &[String],
+) -> Result<BuildStepResult, RezCoreError> {
+    let mut env = environment.get_env_vars().clone();
+    add_windows_runtime_env(&mut env);
+
+    let started_at = Instant::now();
+    let mut command = tokio::process::Command::new("python");
+    command.args(args).env_clear().envs(&env);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+
+    let output = command
+        .output()
+        .await
+        .map_err(|err| RezCoreError::ExecutionError(format!("Failed to run python: {err}")))?;
+
+    Ok(BuildStepResult {
+        step,
+        success: output.status.success(),
+        output: String::from_utf8_lossy(&output.stdout).to_string(),
+        errors: String::from_utf8_lossy(&output.stderr).to_string(),
+        duration_ms: started_at.elapsed().as_millis() as u64,
+    })
+}
+
+fn add_windows_runtime_env(env: &mut std::collections::HashMap<String, String>) {
+    if !cfg!(windows) {
+        return;
+    }
+
+    for key in ["SystemRoot", "WINDIR", "TEMP", "TMP"] {
+        if !env.contains_key(key) {
+            if let Ok(value) = std::env::var(key) {
+                env.insert(key.to_string(), value);
+            }
+        }
+    }
+}
+
+fn env_var_truthy(value: Option<&String>) -> bool {
+    matches!(
+        value.map(|value| value.to_ascii_lowercase()),
+        Some(value) if matches!(value.as_str(), "1" | "true" | "yes" | "on")
+    )
+}
+
+fn step_ok(step: BuildStep, output: &str) -> BuildStepResult {
+    BuildStepResult {
+        step,
+        success: true,
+        output: output.to_string(),
+        errors: String::new(),
+        duration_ms: 0,
+    }
+}

--- a/crates/rez-next-build/src/tests.rs
+++ b/crates/rez-next-build/src/tests.rs
@@ -6,9 +6,12 @@
 #[cfg(test)]
 mod build_tests {
     use crate::*;
+    use rez_next_context::{ContextConfig, ContextStatus, EnvironmentManager, ResolvedContext};
     use rez_next_package::Package;
+    use rez_next_package::PackageRequirement;
     use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::process::Command;
     use tempfile::TempDir;
 
     // ── Helpers ─────────────────────────────────────────────────────────────
@@ -23,11 +26,90 @@ mod build_tests {
         BuildRequest::new(pkg, None, source_dir)
     }
 
+    fn python_executable() -> String {
+        let output = Command::new("python")
+            .args(["-c", "import sys; print(sys.executable)"])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "failed to locate python executable: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn create_python_package(root: &std::path::Path) -> Package {
+        let package_root = root.join("python").join("3.11.0");
+        let bin_dir = package_root.join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::write(
+            package_root.join("package.py"),
+            r#"
+name = "python"
+version = "3.11.0"
+tools = ["python"]
+
+def commands():
+    env.setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+    env.prepend_path("PATH", "{root}/bin")
+"#,
+        )
+        .unwrap();
+
+        let python = python_executable();
+        if cfg!(windows) {
+            std::fs::write(
+                bin_dir.join("python.cmd"),
+                format!("@echo off\r\n\"{}\" %*\r\n", python),
+            )
+            .unwrap();
+        } else {
+            let shim = bin_dir.join("python");
+            std::fs::write(&shim, format!("#!/bin/sh\n\"{}\" \"$@\"\n", python)).unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
+            }
+        }
+
+        Package::from_path(package_root).unwrap()
+    }
+
+    async fn python_build_context(temp_dir: &TempDir) -> ResolvedContext {
+        let package = create_python_package(temp_dir.path());
+        let mut context = ResolvedContext::from_requirements(vec![
+            PackageRequirement::parse("python-3+").unwrap(),
+        ]);
+        context.resolved_packages = vec![package];
+        context.status = ContextStatus::Resolved;
+
+        let manager = EnvironmentManager::new(ContextConfig {
+            inherit_parent_env: false,
+            ..Default::default()
+        });
+        context.environment_vars = manager
+            .generate_environment(&context.resolved_packages)
+            .await
+            .unwrap();
+        context
+    }
+
+    async fn make_request_with_python_context(
+        pkg: Package,
+        source_dir: PathBuf,
+        temp_dir: &TempDir,
+    ) -> BuildRequest {
+        BuildRequest::new(pkg, Some(python_build_context(temp_dir).await), source_dir)
+    }
+
     // ── BuildConfig tests ────────────────────────────────────────────────────
 
     #[test]
     fn test_build_config_defaults() {
         let config = BuildConfig::default();
+        assert_eq!(config.build_dir, PathBuf::from(".rez_build"));
         assert_eq!(config.max_concurrent_builds, 4);
         assert_eq!(config.build_timeout_seconds, 3600);
         assert!(!config.clean_before_build);
@@ -384,6 +466,8 @@ mod build_tests {
         let _ = BuildSystemType::Python;
         let _ = BuildSystemType::NodeJs;
         let _ = BuildSystemType::Cargo;
+        let _ = BuildSystemType::BinaryArchive;
+        let _ = BuildSystemType::Pypi;
         let _ = BuildSystemType::Custom;
         let _ = BuildSystemType::Unknown;
     }
@@ -414,7 +498,7 @@ mod build_tests {
         .unwrap();
 
         let pkg = make_package("testpkg", "1.0.0");
-        let req = make_request(pkg, tmp.path().to_path_buf());
+        let req = make_request_with_python_context(pkg, tmp.path().to_path_buf(), &tmp).await;
         let ids = manager.start_build(req).await.unwrap();
 
         let stats = manager.get_stats();
@@ -454,13 +538,52 @@ if not source_path or not os.path.isdir(source_path):
         .unwrap();
 
         let pkg = make_package("testpkg", "1.0.0");
-        let req = make_request(pkg, tmp.path().to_path_buf());
+        let req = make_request_with_python_context(pkg, tmp.path().to_path_buf(), &tmp).await;
         let ids = manager.start_build(req).await.unwrap();
         let result = manager.wait_for_build(&ids[0]).await.unwrap();
 
         assert!(
             result.success,
             "rezbuild.py should receive REZ_BUILD_SOURCE_PATH: {}",
+            result.errors
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_manager_passes_request_env_vars_to_rezbuild() {
+        let mut manager = BuildManager::new();
+        let tmp = TempDir::new().unwrap();
+
+        std::fs::write(
+            tmp.path().join("package.py"),
+            "name = 'envpkg'\nversion = '1.0.0'\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("rezbuild.py"),
+            r#"
+import os
+import sys
+
+if os.environ.get("VX_REZ_TEST_ARTIFACT") != "artifact.zip":
+    print("missing request env override", file=sys.stderr)
+    sys.exit(1)
+"#,
+        )
+        .unwrap();
+
+        let pkg = make_package("envpkg", "1.0.0");
+        let mut req = make_request_with_python_context(pkg, tmp.path().to_path_buf(), &tmp).await;
+        req.options.env_vars.insert(
+            "VX_REZ_TEST_ARTIFACT".to_string(),
+            "artifact.zip".to_string(),
+        );
+        let ids = manager.start_build(req).await.unwrap();
+        let result = manager.wait_for_build(&ids[0]).await.unwrap();
+
+        assert!(
+            result.success,
+            "rezbuild.py should receive request env overrides: {}",
             result.errors
         );
     }
@@ -502,7 +625,7 @@ for name, check in checks.items():
             vec!["platform-windows".to_string()],
             vec!["platform-linux".to_string()],
         ];
-        let req = make_request(pkg, tmp.path().to_path_buf());
+        let req = make_request_with_python_context(pkg, tmp.path().to_path_buf(), &tmp).await;
         let ids = manager.start_build(req).await.unwrap();
 
         assert_eq!(ids.len(), 2, "each package variant should start a build");
@@ -560,7 +683,7 @@ if os.environ["REZ_BUILD_PROJECT_VERSION"] != "0.0.0":
         .unwrap();
 
         let pkg = Package::new("versionless".to_string());
-        let req = make_request(pkg, tmp.path().to_path_buf());
+        let req = make_request_with_python_context(pkg, tmp.path().to_path_buf(), &tmp).await;
         let ids = manager.start_build(req).await.unwrap();
         let result = manager.wait_for_build(&ids[0]).await.unwrap();
 
@@ -823,6 +946,57 @@ if os.environ["REZ_BUILD_PROJECT_VERSION"] != "0.0.0":
         // Just ensure we got a valid result
         assert!(!build_result.build_id.is_empty());
     }
+
+    #[tokio::test]
+    async fn test_build_manager_emits_live_build_events() {
+        let tmp = TempDir::new().unwrap();
+        let source_dir = tmp.path().join("source");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        std::fs::write(
+            source_dir.join("package.py"),
+            "name = 'event_test'\nversion = '1.0.0'\n",
+        )
+        .unwrap();
+
+        let (event_sender, mut event_receiver) = tokio::sync::mpsc::unbounded_channel();
+        let mut config = BuildConfig::default();
+        config.build_dir = tmp.path().join(".rez_build");
+        config.event_sender = Some(event_sender);
+        let mut manager = BuildManager::with_config(config);
+
+        let pkg = make_package("event_test", "1.0.0");
+        let req = make_request(pkg, source_dir);
+        let build_ids = manager.start_build(req).await.unwrap();
+        let build_id = &build_ids[0];
+        let result = manager.wait_for_build(build_id).await.unwrap();
+        assert!(result.success);
+
+        let mut events = Vec::new();
+        while let Ok(event) = event_receiver.try_recv() {
+            events.push(event);
+        }
+
+        assert!(
+            events
+                .iter()
+                .any(|event| event.kind == BuildEventKind::BuildStarted),
+            "build start event should be emitted"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| event.kind == BuildEventKind::StepStarted
+                    && event.step == Some(BuildStep::Preparing)),
+            "preparing step start event should be emitted"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| event.kind == BuildEventKind::BuildFinished
+                    && event.success == Some(true)),
+            "successful build finish event should be emitted"
+        );
+    }
 }
 
 // ── New tests for BuildType, get_build_process_types, create_build_system ─────
@@ -871,6 +1045,9 @@ mod build_type_tests {
         assert!(create_build_system("python").is_some());
         assert!(create_build_system("nodejs").is_some());
         assert!(create_build_system("cargo").is_some());
+        assert!(create_build_system("binary_archive").is_some());
+        assert!(create_build_system("pypi").is_some());
+        assert!(create_build_system("rez_pip").is_some());
         assert!(create_build_system("custom").is_some());
     }
 

--- a/crates/rez-next-common/src/config.rs
+++ b/crates/rez-next-common/src/config.rs
@@ -224,7 +224,7 @@ impl RezCoreConfig {
 
         // Override with environment variables
         if let Ok(packages_path) = env::var("REZ_PACKAGES_PATH") {
-            config.packages_path = packages_path.split(':').map(ToString::to_string).collect();
+            config.packages_path = split_env_paths(&packages_path);
         }
         if let Ok(local_path) = env::var("REZ_LOCAL_PACKAGES_PATH") {
             config.local_packages_path = local_path;
@@ -251,6 +251,16 @@ impl RezCoreConfig {
 
         Some(current.clone())
     }
+}
+
+fn split_env_paths(paths: &str) -> Vec<String> {
+    let separator = if cfg!(windows) { ';' } else { ':' };
+    paths
+        .split(separator)
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(ToString::to_string)
+        .collect()
 }
 
 #[cfg(test)]
@@ -348,7 +358,11 @@ mod tests {
         // Only safe to test if env var is not already set
         if std::env::var("REZ_PACKAGES_PATH").is_err() {
             unsafe {
-                std::env::set_var("REZ_PACKAGES_PATH", "/tmp/test_pkgs:/tmp/other_pkgs");
+                let separator = if cfg!(windows) { ';' } else { ':' };
+                std::env::set_var(
+                    "REZ_PACKAGES_PATH",
+                    format!("/tmp/test_pkgs{separator}/tmp/other_pkgs"),
+                );
             };
             let cfg = RezCoreConfig::load();
             assert!(cfg.packages_path.contains(&"/tmp/test_pkgs".to_string()));
@@ -356,6 +370,26 @@ mod tests {
                 std::env::remove_var("REZ_PACKAGES_PATH");
             };
         }
+    }
+
+    #[test]
+    fn test_split_env_paths_uses_platform_separator() {
+        let separator = if cfg!(windows) { ';' } else { ':' };
+        let result = split_env_paths(&format!("first{separator}second"));
+        assert_eq!(result, vec!["first".to_string(), "second".to_string()]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_split_env_paths_preserves_windows_drive_letters() {
+        let result = split_env_paths(r"C:\packages\rez;D:\local\packages");
+        assert_eq!(
+            result,
+            vec![
+                r"C:\packages\rez".to_string(),
+                r"D:\local\packages".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/crates/rez-next-context/src/context.rs
+++ b/crates/rez-next-context/src/context.rs
@@ -95,7 +95,7 @@ pub enum PathStrategy {
 impl Default for ContextConfig {
     fn default() -> Self {
         Self {
-            inherit_parent_env: true,
+            inherit_parent_env: false,
             shell_type: ShellType::Bash,
             working_directory: None,
             additional_env_vars: HashMap::new(),
@@ -444,7 +444,7 @@ mod tests {
     fn test_context_config_default() {
         let config = ContextConfig::default();
 
-        assert!(config.inherit_parent_env);
+        assert!(!config.inherit_parent_env);
         assert!(config.additional_env_vars.is_empty());
         assert!(config.unset_vars.is_empty());
         assert_eq!(config.path_strategy, crate::PathStrategy::Prepend);

--- a/crates/rez-next-context/src/environment.rs
+++ b/crates/rez-next-context/src/environment.rs
@@ -7,6 +7,7 @@ use rez_next_rex::RexExecutor;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env;
+use std::path::Path;
 
 /// Environment manager for generating package environments
 // #[pyclass]  // Temporarily disabled due to DLL issues
@@ -107,8 +108,9 @@ impl EnvironmentManager {
     ) -> Result<Vec<EnvVarDefinition>, RezCoreError> {
         let mut definitions = Vec::new();
 
-        // Always set package root and version variables
-        let package_root = format!("/packages/{}", package.name);
+        // Always set package root and version variables. Real repository packages
+        // carry their descriptor path; synthetic packages keep the legacy fallback.
+        let package_root = Self::package_root(package);
         definitions.push(EnvVarDefinition {
             name: format!("{}_ROOT", package.name.to_uppercase()),
             operation: EnvOperation::Set(package_root.clone()),
@@ -157,7 +159,7 @@ impl EnvironmentManager {
 
         // Add tools to PATH
         if !package.tools.is_empty() {
-            let tool_path = format!("{}/bin", package_root);
+            let tool_path = Self::join_root_path(&package_root, "bin");
             definitions.push(EnvVarDefinition {
                 name: "PATH".to_string(),
                 operation: EnvOperation::Prepend(tool_path, get_path_separator()),
@@ -167,6 +169,16 @@ impl EnvironmentManager {
         }
 
         Ok(definitions)
+    }
+
+    fn package_root(package: &Package) -> String {
+        package
+            .root()
+            .unwrap_or_else(|| format!("/packages/{}", package.name))
+    }
+
+    fn join_root_path(root: &str, child: &str) -> String {
+        Path::new(root).join(child).to_string_lossy().to_string()
     }
 
     /// Apply an environment variable definition
@@ -220,7 +232,8 @@ impl EnvironmentManager {
         // Collect tool paths from packages
         for package in packages {
             for _tool in &package.tools {
-                let tool_path = format!("/packages/{}/bin", package.name);
+                let package_root = Self::package_root(package);
+                let tool_path = Self::join_root_path(&package_root, "bin");
                 if !tool_paths.contains(&tool_path) {
                     tool_paths.push(tool_path);
                 }

--- a/crates/rez-next-context/src/execution.rs
+++ b/crates/rez-next-context/src/execution.rs
@@ -30,7 +30,7 @@ impl Default for ExecutionConfig {
         Self {
             shell_type: ShellType::detect(),
             working_directory: None,
-            inherit_parent_env: true,
+            inherit_parent_env: false,
             additional_env_vars: HashMap::new(),
             timeout_seconds: 300, // 5 minutes
             capture_output: true,
@@ -65,6 +65,7 @@ impl ContextExecutor {
 
         let shell_executor = ShellExecutor::with_shell(config.shell_type.clone())
             .with_environment(environment)
+            .with_inherit_parent_env(config.inherit_parent_env)
             .with_timeout(config.timeout_seconds);
 
         let shell_executor = if let Some(ref wd) = config.working_directory {
@@ -192,6 +193,7 @@ impl ContextExecutor {
 
         self.shell_executor = ShellExecutor::with_shell(self.config.shell_type.clone())
             .with_environment(environment)
+            .with_inherit_parent_env(self.config.inherit_parent_env)
             .with_timeout(self.config.timeout_seconds);
 
         if let Some(ref wd) = self.config.working_directory {
@@ -426,7 +428,7 @@ mod tests {
         let config = ExecutionConfig::default();
 
         assert_eq!(config.timeout_seconds, 300);
-        assert!(config.inherit_parent_env);
+        assert!(!config.inherit_parent_env);
         assert!(config.capture_output);
         assert!(config.working_directory.is_none());
         assert_eq!(config.additional_env_vars.len(), 0);

--- a/crates/rez-next-context/src/shell.rs
+++ b/crates/rez-next-context/src/shell.rs
@@ -66,13 +66,8 @@ impl ShellType {
             }
         }
 
-        // Check for Windows
         if cfg!(windows) {
-            if std::env::var("PSModulePath").is_ok() {
-                ShellType::PowerShell
-            } else {
-                ShellType::Cmd
-            }
+            ShellType::Cmd
         } else {
             ShellType::Bash // Default to bash on Unix-like systems
         }
@@ -119,6 +114,8 @@ pub struct ShellExecutor {
     working_directory: Option<PathBuf>,
     /// Environment variables
     environment: HashMap<String, String>,
+    /// Whether to inherit parent process environment
+    inherit_parent_env: bool,
     /// Timeout for command execution (in seconds)
     timeout_seconds: u64,
 }
@@ -135,6 +132,7 @@ impl ShellExecutor {
             shell_type,
             working_directory: None,
             environment: HashMap::new(),
+            inherit_parent_env: false,
             timeout_seconds: 300, // 5 minutes default
         }
     }
@@ -142,6 +140,12 @@ impl ShellExecutor {
     /// Set the environment variables
     pub fn with_environment(mut self, environment: HashMap<String, String>) -> Self {
         self.environment = environment;
+        self
+    }
+
+    /// Set whether child processes inherit the parent environment.
+    pub fn with_inherit_parent_env(mut self, inherit_parent_env: bool) -> Self {
+        self.inherit_parent_env = inherit_parent_env;
         self
     }
 
@@ -173,6 +177,9 @@ impl ShellExecutor {
         }
 
         // Set environment variables
+        if !self.inherit_parent_env {
+            cmd.env_clear();
+        }
         for (key, value) in &self.environment {
             cmd.env(key, value);
         }
@@ -210,6 +217,9 @@ impl ShellExecutor {
         }
 
         // Set environment variables
+        if !self.inherit_parent_env {
+            cmd.env_clear();
+        }
         for (key, value) in &self.environment {
             cmd.env(key, value);
         }

--- a/crates/rez-next-context/src/tests/context_tests.rs
+++ b/crates/rez-next-context/src/tests/context_tests.rs
@@ -4,6 +4,7 @@ mod resolved_context_behavior_tests {
     use crate::{ContextConfig, ContextStatus, EnvironmentManager, PathStrategy, ResolvedContext};
     use rez_next_package::{Package, PackageRequirement};
     use rez_next_version::Version;
+    use std::path::PathBuf;
 
     fn make_package(name: &str, version: &str) -> Package {
         let mut pkg = Package::new(name.to_string());
@@ -16,7 +17,7 @@ mod resolved_context_behavior_tests {
     #[test]
     fn test_context_config_defaults() {
         let cfg = ContextConfig::default();
-        assert!(cfg.inherit_parent_env);
+        assert!(!cfg.inherit_parent_env);
         assert!(cfg.additional_env_vars.is_empty());
         assert!(cfg.unset_vars.is_empty());
         assert_eq!(cfg.path_strategy, PathStrategy::Prepend);
@@ -135,6 +136,37 @@ mod resolved_context_behavior_tests {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let vars = rt.block_on(mgr.generate_environment(&[pkg])).unwrap();
         assert!(vars.contains_key("PYTHON_ROOT"));
+    }
+
+    #[test]
+    fn test_env_manager_uses_package_descriptor_root() {
+        let cfg = ContextConfig {
+            inherit_parent_env: false,
+            ..Default::default()
+        };
+        let mgr = EnvironmentManager::new(cfg);
+        let mut pkg = make_package("python", "3.9.0");
+        let package_root = PathBuf::from("/tmp/vx-cache/bundles/python/3.9.0");
+        pkg.filepath = Some(
+            package_root
+                .join("package.py")
+                .to_string_lossy()
+                .to_string(),
+        );
+        pkg.commands = Some("env.setenv('PYTHON_HOME', '{root}')".to_string());
+        pkg.tools = vec!["python".to_string()];
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let vars = rt.block_on(mgr.generate_environment(&[pkg])).unwrap();
+        let root = package_root.to_string_lossy().to_string();
+
+        assert_eq!(vars.get("PYTHON_ROOT"), Some(&root));
+        assert_eq!(vars.get("PYTHON_HOME"), Some(&root));
+        assert!(
+            vars.get("PATH")
+                .map(|value| value.contains(&package_root.join("bin").to_string_lossy().to_string()))
+                .unwrap_or(false)
+        );
     }
 
     #[test]

--- a/crates/rez-next-context/src/tests/execution_tests.rs
+++ b/crates/rez-next-context/src/tests/execution_tests.rs
@@ -28,8 +28,8 @@ mod execution_behavior_tests {
     fn test_execution_config_defaults() {
         let cfg = ExecutionConfig::default();
         assert!(
-            cfg.inherit_parent_env,
-            "Should inherit parent env by default"
+            !cfg.inherit_parent_env,
+            "Should isolate parent env by default"
         );
         assert!(cfg.additional_env_vars.is_empty());
         assert!(cfg.working_directory.is_none());

--- a/crates/rez-next-python/python/rez_next/build_plugins.py
+++ b/crates/rez-next-python/python/rez_next/build_plugins.py
@@ -1,0 +1,276 @@
+"""Reusable build helpers for Rez package build scripts.
+
+These helpers are intentionally small and subclass-friendly. They cover common
+pipeline package patterns while keeping package-specific policy in `rezbuild.py`
+or `build.py`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class BuildContext:
+    source_path: Path
+    build_path: Path
+    install_path: Path
+    package_name: str
+    package_version: str
+    variant_index: int
+    variant_requires: tuple[str, ...]
+    host_platform: str
+    host_arch: str
+    target_platform: str
+    target_arch: str
+    target_os: str
+
+    @classmethod
+    def from_env(cls) -> "BuildContext":
+        source_path = Path(os.environ.get("REZ_BUILD_SOURCE_PATH", os.getcwd())).resolve()
+        build_path = Path(os.environ.get("REZ_BUILD_PATH", source_path / ".rez_build")).resolve()
+        install_path = Path(os.environ.get("REZ_BUILD_INSTALL_PATH", build_path / "install")).resolve()
+        host_platform = _host_platform()
+        target_platform = os.environ.get("REZ_BUILD_TARGET_PLATFORM", host_platform)
+        target_arch = os.environ.get("REZ_BUILD_TARGET_ARCH", platform.machine().lower())
+        target_os = os.environ.get("REZ_BUILD_TARGET_OS", target_platform.split("-", 1)[0])
+        variant_requires = tuple(
+            req
+            for req in os.environ.get("REZ_BUILD_VARIANT_REQUIRES", "").split()
+            if req
+        )
+        return cls(
+            source_path=source_path,
+            build_path=build_path,
+            install_path=install_path,
+            package_name=os.environ.get("REZ_BUILD_PACKAGE_NAME", ""),
+            package_version=os.environ.get("REZ_BUILD_PACKAGE_VERSION", ""),
+            variant_index=int(os.environ.get("REZ_BUILD_VARIANT_INDEX", "0") or "0"),
+            variant_requires=variant_requires,
+            host_platform=host_platform,
+            host_arch=platform.machine().lower(),
+            target_platform=target_platform,
+            target_arch=target_arch,
+            target_os=target_os,
+        )
+
+
+class BuildPlugin:
+    """Base class for `rezbuild.py`/`build.py` helpers."""
+
+    def __init__(self, context: BuildContext | None = None) -> None:
+        self.context = context or BuildContext.from_env()
+
+    def run(self, command: str | None = None) -> None:
+        command = command or (sys.argv[1] if len(sys.argv) > 1 else "install")
+        if command == "build":
+            self.build()
+            return
+        if command == "install":
+            self.install()
+            return
+        if command in {"clean", "test"}:
+            return
+        raise ValueError(f"Unsupported build command: {command}")
+
+    def build(self) -> None:
+        print(f"{self.__class__.__name__}: build step ready")
+
+    def install(self) -> None:
+        raise NotImplementedError
+
+    def resolve_path(self, value: str | os.PathLike[str]) -> Path:
+        path = Path(value)
+        if not path.is_absolute():
+            path = self.context.source_path / path
+        return path.resolve()
+
+
+class ExtractionBuilder(BuildPlugin):
+    """Download or reuse an archive, verify it, extract it, and copy payload."""
+
+    artifact: str | os.PathLike[str] | None = None
+    url: str | None = None
+    sha256: str | None = None
+    sha256_file: str | os.PathLike[str] | None = None
+    payload_prefix: str | os.PathLike[str] | None = None
+
+    def __init__(
+        self,
+        *,
+        artifact: str | os.PathLike[str] | None = None,
+        url: str | None = None,
+        sha256: str | None = None,
+        sha256_file: str | os.PathLike[str] | None = None,
+        payload_prefix: str | os.PathLike[str] | None = None,
+        context: BuildContext | None = None,
+    ) -> None:
+        super().__init__(context=context)
+        self.artifact = artifact if artifact is not None else self.artifact
+        self.url = url if url is not None else self.url
+        self.sha256 = sha256 if sha256 is not None else self.sha256
+        self.sha256_file = sha256_file if sha256_file is not None else self.sha256_file
+        self.payload_prefix = payload_prefix if payload_prefix is not None else self.payload_prefix
+
+    def select_artifact(self) -> Path:
+        if self.artifact:
+            artifact = self.resolve_path(self.artifact)
+            if not artifact.is_file():
+                raise FileNotFoundError(f"archive artifact does not exist: {artifact}")
+            return artifact
+        if not self.url:
+            raise ValueError("ExtractionBuilder requires artifact or url")
+
+        downloads = self.context.build_path / "downloads"
+        downloads.mkdir(parents=True, exist_ok=True)
+        filename = self.url.rsplit("/", 1)[-1] or "artifact"
+        destination = downloads / filename
+        urllib.request.urlretrieve(self.url, destination)
+        return destination
+
+    def expected_sha256(self) -> str | None:
+        if self.sha256:
+            return self.sha256.strip()
+        if self.sha256_file:
+            return self.resolve_path(self.sha256_file).read_text(encoding="utf-8").strip()
+        return None
+
+    def install(self) -> None:
+        artifact = self.select_artifact()
+        expected = self.expected_sha256()
+        if expected:
+            verify_sha256(artifact, expected)
+
+        extract_dir = self.context.build_path / "extract"
+        if extract_dir.exists():
+            shutil.rmtree(extract_dir)
+        extract_dir.mkdir(parents=True, exist_ok=True)
+        extract_archive(artifact, extract_dir)
+
+        payload = extract_dir / self.payload_prefix if self.payload_prefix else extract_dir
+        if not payload.is_dir():
+            raise FileNotFoundError(f"archive payload directory does not exist: {payload}")
+        copy_tree_contents(payload, self.context.install_path)
+        print(f"{self.__class__.__name__}: installed {artifact} -> {self.context.install_path}")
+
+
+class PipFromDownloadBuilder(BuildPlugin):
+    """Install a pip-compatible package artifact or spec into a Rez package."""
+
+    package: str | os.PathLike[str] | None = None
+    requirement: str | os.PathLike[str] | None = None
+    extra_args: Sequence[str] = ()
+    with_deps: bool = False
+    target_subdir: str = "python"
+
+    def __init__(
+        self,
+        *,
+        package: str | os.PathLike[str] | None = None,
+        requirement: str | os.PathLike[str] | None = None,
+        extra_args: Sequence[str] = (),
+        with_deps: bool | None = None,
+        target_subdir: str | None = None,
+        context: BuildContext | None = None,
+    ) -> None:
+        super().__init__(context=context)
+        self.package = package if package is not None else self.package
+        self.requirement = requirement if requirement is not None else self.requirement
+        self.extra_args = tuple(extra_args or self.extra_args)
+        self.with_deps = self.with_deps if with_deps is None else with_deps
+        self.target_subdir = target_subdir or self.target_subdir
+
+    def install(self) -> None:
+        target = self.context.install_path / self.target_subdir
+        target.mkdir(parents=True, exist_ok=True)
+
+        args = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "--target",
+            str(target),
+        ]
+        if not self.with_deps:
+            args.append("--no-deps")
+        args.extend(self.extra_args)
+        if self.requirement:
+            args.extend(["-r", str(self.resolve_path(self.requirement))])
+        if self.package:
+            package = self.resolve_path(self.package) if _looks_like_path(self.package) else self.package
+            args.append(str(package))
+        if not self.package and not self.requirement:
+            raise ValueError("PipFromDownloadBuilder requires package or requirement")
+
+        subprocess.run(args, cwd=self.context.source_path, env=_subprocess_env(), check=True)
+        print(f"{self.__class__.__name__}: installed pip payload -> {target}")
+
+
+def verify_sha256(path: Path, expected: str) -> None:
+    hasher = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    actual = hasher.hexdigest()
+    if actual != expected:
+        raise ValueError(f"archive sha256 mismatch: expected {expected}, got {actual}")
+
+
+def extract_archive(artifact: Path, destination: Path) -> None:
+    name = artifact.name.lower()
+    if name.endswith(".zip") or name.endswith(".whl"):
+        with zipfile.ZipFile(artifact) as archive:
+            archive.extractall(destination)
+        return
+    if name.endswith(".tar.gz") or name.endswith(".tgz"):
+        with tarfile.open(artifact, "r:gz") as archive:
+            archive.extractall(destination)
+        return
+    raise ValueError(f"unsupported archive format: {artifact}")
+
+
+def copy_tree_contents(source: Path, destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    for entry in source.iterdir():
+        target = destination / entry.name
+        if entry.is_dir():
+            if target.exists():
+                shutil.rmtree(target)
+            shutil.copytree(entry, target)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(entry, target)
+
+
+def _looks_like_path(value: str | os.PathLike[str]) -> bool:
+    text = os.fspath(value)
+    return any(sep in text for sep in ("/", "\\")) or text.endswith((".whl", ".zip", ".tar.gz", ".tgz"))
+
+
+def _host_platform() -> str:
+    system = platform.system().lower()
+    if system == "darwin":
+        system = "macos"
+    return f"{system}-{platform.machine().lower()}"
+
+
+def _subprocess_env() -> dict[str, str]:
+    env = dict(os.environ)
+    if os.name == "nt":
+        for key in ("SystemRoot", "WINDIR", "TEMP", "TMP"):
+            if key not in env and key in os.environ:
+                env[key] = os.environ[key]
+    return env

--- a/crates/rez-next-python/python/rez_next/test.py
+++ b/crates/rez-next-python/python/rez_next/test.py
@@ -1,0 +1,11 @@
+"""rez_next.test - package test compatibility API."""
+
+import rez_next._native  # noqa: F401
+from rez_next._native.test import (  # noqa: F401
+    ERROR,
+    FAILED,
+    SKIPPED,
+    SUCCESS,
+    PackageTestResults,
+    PackageTestRunner,
+)

--- a/crates/rez-next-python/src/build_bindings.rs
+++ b/crates/rez-next-python/src/build_bindings.rs
@@ -99,6 +99,8 @@ impl PyBuildSystem {
             BuildSystem::Python(_) => "python".to_string(),
             BuildSystem::NodeJs(_) => "nodejs".to_string(),
             BuildSystem::Cargo(_) => "cargo".to_string(),
+            BuildSystem::BinaryArchive(_) => "binary_archive".to_string(),
+            BuildSystem::Pypi(_) => "pypi".to_string(),
             BuildSystem::Custom(_) => "custom".to_string(),
         }
     }

--- a/crates/rez-next-repository/src/simple_repository.rs
+++ b/crates/rez-next-repository/src/simple_repository.rs
@@ -110,7 +110,9 @@ impl SimpleRepository {
         &self,
         descriptor_path: &Path,
     ) -> Result<Package, RezCoreError> {
-        PackageSerializer::load_from_file(descriptor_path)
+        let mut package = PackageSerializer::load_from_file(descriptor_path)?;
+        package.filepath = Some(descriptor_path.to_string_lossy().to_string());
+        Ok(package)
     }
 }
 

--- a/examples/build_plugins/extraction_vx/package.py
+++ b/examples/build_plugins/extraction_vx/package.py
@@ -1,0 +1,14 @@
+"""Example Rez package using rez_next.build_plugins.ExtractionBuilder."""
+
+name = "vx"
+version = "0.0.1"
+description = "Example binary extraction package"
+tools = ["vx"]
+
+tests = {
+    "run": "vx",
+}
+
+
+def commands():
+    env.PATH.prepend("{root}/bin")

--- a/examples/build_plugins/extraction_vx/rezbuild.py
+++ b/examples/build_plugins/extraction_vx/rezbuild.py
@@ -1,0 +1,13 @@
+from rez_next.build_plugins import ExtractionBuilder
+
+
+class VxExtractionBuilder(ExtractionBuilder):
+    def __init__(self):
+        super().__init__(
+            artifact="dist/vx-artifact.zip",
+            sha256_file="dist/vx-artifact.sha256",
+        )
+
+
+if __name__ == "__main__":
+    VxExtractionBuilder().run()

--- a/examples/build_plugins/pypi_wheel/package.py
+++ b/examples/build_plugins/pypi_wheel/package.py
@@ -1,0 +1,16 @@
+"""Example Rez package using rez_next.build_plugins.PipFromDownloadBuilder."""
+
+name = "pypi_sample"
+version = "1.0.0"
+description = "Example package installed from a pip-compatible wheel"
+
+requires = ["python-3+"]
+build_requires = ["python-3+"]
+
+tests = {
+    "import": "python -c \"import pypi_sample; print(pypi_sample.VALUE)\"",
+}
+
+
+def commands():
+    env.PYTHONPATH.prepend("{root}/python")

--- a/examples/build_plugins/pypi_wheel/rezbuild.py
+++ b/examples/build_plugins/pypi_wheel/rezbuild.py
@@ -1,0 +1,13 @@
+from rez_next.build_plugins import PipFromDownloadBuilder
+
+
+class SampleWheelBuilder(PipFromDownloadBuilder):
+    def __init__(self):
+        super().__init__(
+            package="dist/pypi_sample-1.0.0-py3-none-any.whl",
+            extra_args=["--no-index"],
+        )
+
+
+if __name__ == "__main__":
+    SampleWheelBuilder().run()

--- a/python/rez_next/build_plugins.py
+++ b/python/rez_next/build_plugins.py
@@ -1,0 +1,15 @@
+"""Reusable build helpers for Rez package build scripts."""
+
+from pathlib import Path
+import runpy
+
+_IMPL = (
+    Path(__file__).resolve().parents[2]
+    / "crates"
+    / "rez-next-python"
+    / "python"
+    / "rez_next"
+    / "build_plugins.py"
+)
+
+globals().update(runpy.run_path(str(_IMPL)))

--- a/src/cli/commands/build.rs
+++ b/src/cli/commands/build.rs
@@ -2,12 +2,38 @@
 //!
 //! Implements the `rez build` command for building packages from source.
 
-use clap::Args;
-use rez_next_build::{BuildManager, BuildOptions, BuildRequest};
-use rez_next_common::{RezCoreError, error::RezCoreResult};
-use rez_next_package::Package;
-use std::collections::HashMap;
+use clap::{Args, ValueEnum};
+use crossterm::{
+    event::{self, Event, KeyCode},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{
+    Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+};
+use rez_next_build::{
+    BuildConfig, BuildEvent, BuildEventKind, BuildManager, BuildOptions, BuildRequest, BuildStatus,
+    BuildStep,
+};
+use rez_next_common::{RezCoreError, config::RezCoreConfig, error::RezCoreResult};
+use rez_next_context::{ContextConfig, EnvironmentManager, ResolvedContext};
+use rez_next_package::{Package, PackageRequirement, Requirement};
+use rez_next_repository::simple_repository::{RepositoryManager, SimpleRepository};
+use rez_next_solver::{DependencyResolver, SolverConfig};
+use std::collections::{HashMap, HashSet};
+use std::io;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc;
+
+use crate::cli::utils::expand_home_path;
 
 /// Arguments for the build command
 #[derive(Args, Clone, Debug)]
@@ -72,6 +98,14 @@ pub struct BuildArgs {
     #[arg(short = 'v', long = "verbose")]
     pub verbose: bool,
 
+    /// Build log display mode
+    #[arg(long = "output", value_enum, default_value_t = BuildOutputMode::Auto)]
+    pub output: BuildOutputMode,
+
+    /// Open an interactive terminal build report when the terminal supports it
+    #[arg(long = "tui")]
+    pub tui: bool,
+
     /// Package source (directory, URL, or Git repository)
     /// Examples:
     /// - Local directory: ./my-package or /path/to/package
@@ -91,12 +125,34 @@ pub struct BuildArgs {
     pub reference: Option<String>,
 }
 
+/// Build output display mode.
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum BuildOutputMode {
+    /// Show a compact Rez-style report with key log lines
+    Auto,
+    /// Collapse noisy build logs and show only important lines
+    Compact,
+    /// Expand all captured build output
+    Full,
+}
+
+impl BuildOutputMode {
+    fn effective(self) -> Self {
+        match self {
+            BuildOutputMode::Auto => {
+                if std::io::stdout().is_terminal() {
+                    BuildOutputMode::Compact
+                } else {
+                    BuildOutputMode::Compact
+                }
+            }
+            other => other,
+        }
+    }
+}
+
 /// Execute the build command
 pub fn execute(args: BuildArgs) -> RezCoreResult<()> {
-    if args.verbose {
-        println!("🔨 Starting package build...");
-    }
-
     // Determine source directory first
     let (source_dir, package) = if let Some(ref source_url) = args.source {
         // Network or remote source
@@ -113,17 +169,7 @@ pub fn execute(args: BuildArgs) -> RezCoreResult<()> {
         return view_preprocessed_package_with_data(&package);
     }
 
-    if args.verbose {
-        println!(
-            "📦 Building package: {} {}",
-            package.name,
-            package
-                .version
-                .as_ref()
-                .map(|v| v.as_str())
-                .unwrap_or("unknown")
-        );
-    }
+    print_package_build_header(&package);
 
     // Create build options
     let build_options = BuildOptions {
@@ -131,7 +177,7 @@ pub fn execute(args: BuildArgs) -> RezCoreResult<()> {
         skip_tests: args.skip_tests,
         release_mode: args.release,
         build_args: parse_build_args(&args.build_args),
-        env_vars: HashMap::new(),
+        env_vars: collect_build_plugin_env_vars(),
     };
 
     // Determine install path if installing
@@ -183,14 +229,25 @@ pub fn execute(args: BuildArgs) -> RezCoreResult<()> {
         println!("🔀 Building {} variants...", variant_indices.len());
     }
 
-    for variant_idx in variant_indices {
+    let total_variants = variant_indices.len();
+    for (variant_number, variant_idx) in variant_indices.into_iter().enumerate() {
+        print_variant_header(variant_idx.unwrap_or(0), variant_number + 1, total_variants);
+
         // Convert variant index to variant_requires
         let variant_requires: Option<Vec<String>> =
             variant_idx.map(|i| package.variants.get(i).cloned().unwrap_or_default());
 
+        let context = resolve_build_context(&package, variant_requires.as_deref(), args.verbose)?;
+        print_resolve_summary(
+            &package,
+            variant_requires.as_deref(),
+            context.as_ref(),
+            args.output,
+        );
+
         let build_request = BuildRequest {
             package: package.clone(),
-            context: None,
+            context,
             source_dir: source_dir.clone(),
             variant_index: variant_idx,
             variant_requires,
@@ -268,22 +325,21 @@ fn copy_to_persistent_location(source_path: &PathBuf, package: &Package) -> RezC
     })?;
 
     // Create unique directory for this package
+    let unique_suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
     let package_cache_dir = cache_dir.join(format!(
-        "{}-{}",
+        "{}-{}-{}-{}",
         package.name,
         package
             .version
             .as_ref()
             .map(|v| v.as_str())
-            .unwrap_or("unknown")
+            .unwrap_or("unknown"),
+        std::process::id(),
+        unique_suffix
     ));
-
-    // Remove existing cache if present
-    if package_cache_dir.exists() {
-        fs::remove_dir_all(&package_cache_dir).map_err(|e| {
-            RezCoreError::BuildError(format!("Failed to remove existing cache: {}", e))
-        })?;
-    }
 
     // Copy source to cache directory
     copy_dir_recursive(source_path, &package_cache_dir)?;
@@ -325,12 +381,192 @@ fn load_current_package(working_dir: &Path) -> RezCoreResult<Package> {
         .map_err(|e| RezCoreError::PackageParse(format!("Failed to load package: {}", e)))
 }
 
+fn resolve_build_context(
+    package: &Package,
+    variant_requires: Option<&[String]>,
+    verbose: bool,
+) -> RezCoreResult<Option<ResolvedContext>> {
+    let requirement_strings = collect_build_context_requirements(package, variant_requires);
+    if requirement_strings.is_empty() {
+        return Ok(None);
+    }
+
+    if verbose {
+        println!(
+            "🔎 Resolving build environment: {}",
+            requirement_strings.join(", ")
+        );
+    }
+
+    let mut repo_manager = RepositoryManager::new();
+    let config = RezCoreConfig::load();
+    for (index, search_path) in config.packages_path.iter().enumerate() {
+        let path = expand_home_path(search_path);
+        if path.exists() {
+            repo_manager.add_repository(Box::new(SimpleRepository::new(
+                path,
+                format!("build_repo_{}", index),
+            )));
+        }
+    }
+
+    let requirements = requirement_strings
+        .iter()
+        .map(|requirement| {
+            requirement.parse::<Requirement>().map_err(|err| {
+                RezCoreError::RequirementParse(format!(
+                    "Failed to parse build requirement '{}': {}",
+                    requirement, err
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let context_requirements = requirement_strings
+        .iter()
+        .map(|requirement| {
+            PackageRequirement::parse(requirement).map_err(|err| {
+                RezCoreError::RequirementParse(format!(
+                    "Failed to parse build context requirement '{}': {}",
+                    requirement, err
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| RezCoreError::BuildError(format!("Failed to create async runtime: {}", e)))?;
+    let mut resolver = DependencyResolver::new(
+        Arc::new(repo_manager),
+        SolverConfig {
+            strict_mode: true,
+            ..SolverConfig::default()
+        },
+    );
+    let resolution = rt.block_on(resolver.resolve(requirements))?;
+
+    let mut context = ResolvedContext::from_requirements(context_requirements);
+    context.resolved_packages = resolution
+        .resolved_packages
+        .into_iter()
+        .map(|info| (*info.package).clone())
+        .collect();
+    context.status = rez_next_context::ContextStatus::Resolved;
+
+    let env_manager = EnvironmentManager::new(ContextConfig {
+        inherit_parent_env: false,
+        ..Default::default()
+    });
+    context.environment_vars =
+        rt.block_on(env_manager.generate_environment(&context.resolved_packages))?;
+
+    Ok(Some(context))
+}
+
+fn collect_build_context_requirements(
+    package: &Package,
+    variant_requires: Option<&[String]>,
+) -> Vec<String> {
+    let mut requirements = Vec::new();
+    for requirement in package
+        .requires
+        .iter()
+        .chain(package.build_requires.iter())
+        .chain(package.private_build_requires.iter())
+        .chain(variant_requires.unwrap_or(&[]).iter())
+    {
+        if !requirements.contains(requirement) {
+            requirements.push(requirement.clone());
+        }
+    }
+    requirements
+}
+
+fn print_package_build_header(package: &Package) {
+    print_banner(&format!("Building {}...", package_label(package)));
+}
+
+fn print_variant_header(variant_index: usize, variant_number: usize, total_variants: usize) {
+    print_banner(&format!(
+        "Building variant {} ({}/{})...",
+        variant_index, variant_number, total_variants
+    ));
+}
+
+fn print_resolve_summary(
+    package: &Package,
+    variant_requires: Option<&[String]>,
+    context: Option<&ResolvedContext>,
+    output_mode: BuildOutputMode,
+) {
+    let requirements = collect_build_context_requirements(package, variant_requires);
+    if requirements.is_empty() {
+        println!("Resolving build environment: none");
+        println!();
+        return;
+    }
+
+    println!("Resolving build environment: {}", requirements.join(" "));
+    if let Some(context) = context {
+        println!();
+        println!("requested packages:");
+        print_collapsible_lines(
+            requirements.iter().map(String::as_str),
+            output_mode,
+            16,
+            "requested package",
+        );
+        println!();
+        println!("resolved packages:");
+        let resolved_lines = context.resolved_packages.iter().map(|package| {
+            let version = package
+                .version
+                .as_ref()
+                .map(|version| version.as_str())
+                .unwrap_or("unknown");
+            let root = package
+                .root()
+                .map(|path| path.to_string())
+                .unwrap_or_else(|| "<unknown>".to_string());
+            format!("{:<28} {}", format!("{}-{}", package.name, version), root)
+        });
+        print_collapsible_lines(resolved_lines, output_mode, 24, "resolved package");
+    }
+    println!();
+}
+
+fn print_banner(title: &str) {
+    let line = "=".repeat(80);
+    println!("{line}");
+    println!("{title}");
+    println!("{line}");
+    println!();
+}
+
+fn package_label(package: &Package) -> String {
+    package
+        .version
+        .as_ref()
+        .map(|version| format!("{}-{}", package.name, version.as_str()))
+        .unwrap_or_else(|| package.name.clone())
+}
+
 /// Parse build arguments string into vector
 fn parse_build_args(args_str: &Option<String>) -> Vec<String> {
     match args_str {
         Some(args) => args.split_whitespace().map(|s| s.to_string()).collect(),
         None => Vec::new(),
     }
+}
+
+fn collect_build_plugin_env_vars() -> HashMap<String, String> {
+    std::env::vars()
+        .filter(|(key, _)| {
+            key.starts_with("REZ_BINARY_ARCHIVE_")
+                || key.starts_with("REZ_PYPI_")
+                || key.starts_with("REZ_BUILD_TARGET_")
+        })
+        .collect()
 }
 
 /// View preprocessed package definition with package data
@@ -373,16 +609,20 @@ fn execute_build(
     _package: &Package,
     _source_dir: &PathBuf,
 ) -> RezCoreResult<()> {
-    // Create build manager
-    let mut build_manager = BuildManager::new();
+    let (event_sender, event_receiver) = mpsc::unbounded_channel();
+    let mut build_config = BuildConfig::default();
+    build_config.event_sender = Some(event_sender);
+    let mut build_manager = BuildManager::with_config(build_config);
 
     if args.verbose {
         println!("🔧 Configuring build environment...");
     }
 
     // Start build process
-    let runtime = tokio::runtime::Runtime::new()
+    let runtime = Runtime::new()
         .map_err(|e| RezCoreError::BuildError(format!("Failed to create async runtime: {}", e)))?;
+    let package = request.package.clone();
+    let variant_index = request.variant_index;
 
     // start_build() now returns Vec<String> (for variant builds)
     let build_ids: Vec<String> =
@@ -395,22 +635,26 @@ fn execute_build(
         }
     }
 
-    // Wait for all builds to complete
-    let mut final_result = None;
-    for build_id in &build_ids {
-        let build_result =
-            runtime.block_on(async { build_manager.wait_for_build(build_id).await })?;
-        if args.verbose {
-            println!(
-                "✅ Build {} completed: success={}",
-                build_id, build_result.success
-            );
-        }
-        if final_result.is_none() {
-            final_result = Some(build_result);
-        }
-    }
-    let build_result = final_result.ok_or_else(|| {
+    let results = if args.tui && std::io::stdout().is_terminal() {
+        wait_for_builds_with_tui(
+            &runtime,
+            &mut build_manager,
+            &build_ids,
+            event_receiver,
+            &package,
+            variant_index,
+            args.output,
+        )?
+    } else {
+        wait_for_builds_with_text(
+            &runtime,
+            &mut build_manager,
+            &build_ids,
+            event_receiver,
+            args.output,
+        )?
+    };
+    let build_result = results.into_iter().next().ok_or_else(|| {
         RezCoreError::BuildError(
             "No build occurred - no package specifications provided".to_string(),
         )
@@ -423,6 +667,8 @@ fn execute_build(
         )));
     }
 
+    print_build_success_summary(1, &TermStyle::detect());
+
     // Installation is handled by the build system's install step
     // No need for separate installation logic here
 
@@ -431,6 +677,589 @@ fn execute_build(
     }
 
     Ok(())
+}
+
+fn wait_for_builds_with_text(
+    runtime: &Runtime,
+    build_manager: &mut BuildManager,
+    build_ids: &[String],
+    mut event_receiver: mpsc::UnboundedReceiver<BuildEvent>,
+    output_mode: BuildOutputMode,
+) -> RezCoreResult<Vec<rez_next_build::BuildResult>> {
+    let mut renderer = LiveTextBuildRenderer::new(output_mode);
+    while !all_builds_finished(build_manager, build_ids) {
+        while let Ok(event) = event_receiver.try_recv() {
+            renderer.on_event(event);
+        }
+        runtime.block_on(async { tokio::time::sleep(std::time::Duration::from_millis(50)).await });
+    }
+
+    while let Ok(event) = event_receiver.try_recv() {
+        renderer.on_event(event);
+    }
+
+    collect_build_results(runtime, build_manager, build_ids)
+}
+
+fn wait_for_builds_with_tui(
+    runtime: &Runtime,
+    build_manager: &mut BuildManager,
+    build_ids: &[String],
+    mut event_receiver: mpsc::UnboundedReceiver<BuildEvent>,
+    package: &Package,
+    variant_index: Option<usize>,
+    output_mode: BuildOutputMode,
+) -> RezCoreResult<Vec<rez_next_build::BuildResult>> {
+    let mut stdout = io::stdout();
+    enable_raw_mode().map_err(|err| RezCoreError::BuildError(err.to_string()))?;
+    execute!(stdout, EnterAlternateScreen)
+        .map_err(|err| RezCoreError::BuildError(err.to_string()))?;
+
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal =
+        Terminal::new(backend).map_err(|err| RezCoreError::BuildError(err.to_string()))?;
+    let install_path = package_install_preview(build_manager);
+    let mut app = BuildTuiApp::live(package, variant_index, install_path, output_mode);
+    let result = run_live_build_tui(
+        runtime,
+        build_manager,
+        build_ids,
+        &mut event_receiver,
+        &mut terminal,
+        &mut app,
+    );
+
+    disable_raw_mode().map_err(|err| RezCoreError::BuildError(err.to_string()))?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)
+        .map_err(|err| RezCoreError::BuildError(err.to_string()))?;
+    terminal
+        .show_cursor()
+        .map_err(|err| RezCoreError::BuildError(err.to_string()))?;
+
+    result?;
+    collect_build_results(runtime, build_manager, build_ids)
+}
+
+fn run_live_build_tui(
+    runtime: &Runtime,
+    build_manager: &BuildManager,
+    build_ids: &[String],
+    event_receiver: &mut mpsc::UnboundedReceiver<BuildEvent>,
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut BuildTuiApp,
+) -> RezCoreResult<()> {
+    loop {
+        while let Ok(event) = event_receiver.try_recv() {
+            app.on_event(event);
+        }
+
+        terminal
+            .draw(|frame| draw_build_tui(frame, app))
+            .map_err(|err| RezCoreError::BuildError(err.to_string()))?;
+
+        if event::poll(std::time::Duration::from_millis(40))
+            .map_err(|err| RezCoreError::BuildError(err.to_string()))?
+        {
+            if let Event::Key(key) =
+                event::read().map_err(|err| RezCoreError::BuildError(err.to_string()))?
+            {
+                match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc if app.finished => break,
+                    KeyCode::Down | KeyCode::Char('j') => app.next(),
+                    KeyCode::Up | KeyCode::Char('k') => app.previous(),
+                    KeyCode::Enter | KeyCode::Char(' ') => app.toggle_selected(),
+                    KeyCode::Char('c') => app.toggle_mode(),
+                    _ => {}
+                }
+            }
+        }
+
+        if all_builds_finished(build_manager, build_ids) {
+            while let Ok(event) = event_receiver.try_recv() {
+                app.on_event(event);
+            }
+            app.finished = true;
+            terminal
+                .draw(|frame| draw_build_tui(frame, app))
+                .map_err(|err| RezCoreError::BuildError(err.to_string()))?;
+            break;
+        }
+
+        runtime.block_on(async { tokio::time::sleep(std::time::Duration::from_millis(25)).await });
+    }
+
+    Ok(())
+}
+
+fn collect_build_results(
+    runtime: &Runtime,
+    build_manager: &mut BuildManager,
+    build_ids: &[String],
+) -> RezCoreResult<Vec<rez_next_build::BuildResult>> {
+    let mut results = Vec::new();
+    for build_id in build_ids {
+        results.push(runtime.block_on(async { build_manager.wait_for_build(build_id).await })?);
+    }
+    Ok(results)
+}
+
+fn all_builds_finished(build_manager: &BuildManager, build_ids: &[String]) -> bool {
+    build_ids.iter().all(|build_id| {
+        matches!(
+            build_manager.get_build_status(build_id),
+            Some(BuildStatus::Success | BuildStatus::Failed | BuildStatus::Cancelled)
+        )
+    })
+}
+
+fn package_install_preview(build_manager: &BuildManager) -> String {
+    build_manager
+        .get_config()
+        .build_dir
+        .join("<package>")
+        .display()
+        .to_string()
+}
+
+struct LiveTextBuildRenderer {
+    output_mode: BuildOutputMode,
+    term: TermStyle,
+    seen_output: HashSet<(String, String)>,
+}
+
+impl LiveTextBuildRenderer {
+    fn new(output_mode: BuildOutputMode) -> Self {
+        println!("Invoking build system...");
+        Self {
+            output_mode,
+            term: TermStyle::detect(),
+            seen_output: HashSet::new(),
+        }
+    }
+
+    fn on_event(&mut self, event: BuildEvent) {
+        match event.kind {
+            BuildEventKind::BuildStarted => {
+                println!("{}", event.message);
+            }
+            BuildEventKind::StepStarted => {
+                if let Some(step) = event.step {
+                    println!(
+                        "{}",
+                        self.term
+                            .step(&format!("  {:<11} running", step_label(&step)))
+                    );
+                }
+            }
+            BuildEventKind::StepOutput => {
+                if self.remember_output(&event)
+                    && (matches!(self.output_mode.effective(), BuildOutputMode::Full)
+                        || should_show_build_line(&event.message))
+                {
+                    println!("    {}", event.message.trim());
+                }
+            }
+            BuildEventKind::StepError => {
+                if self.remember_output(&event) {
+                    eprintln!("    {}", event.message.trim());
+                }
+            }
+            BuildEventKind::StepFinished => {
+                if let Some(step) = event.step {
+                    let status = if event.success.unwrap_or(false) {
+                        self.term.ok("ok")
+                    } else {
+                        "failed".to_string()
+                    };
+                    let duration = event
+                        .duration_ms
+                        .map(|duration| format!(" ({duration} ms)"))
+                        .unwrap_or_default();
+                    println!(
+                        "{} {}{}",
+                        self.term.step(&format!("  {:<11}", step_label(&step))),
+                        status,
+                        duration
+                    );
+                }
+            }
+            BuildEventKind::BuildFinished => {
+                if !event.success.unwrap_or(false) {
+                    eprintln!("{}", event.message);
+                }
+            }
+        }
+    }
+
+    fn remember_output(&mut self, event: &BuildEvent) -> bool {
+        let step = event
+            .step
+            .as_ref()
+            .map(step_label)
+            .unwrap_or("build")
+            .to_string();
+        self.seen_output.insert((step, event.message.clone()))
+    }
+}
+
+struct BuildTuiApp {
+    package_label: String,
+    install_path: String,
+    sections: Vec<BuildOutputSection>,
+    selected: usize,
+    expanded: Vec<bool>,
+    output_mode: BuildOutputMode,
+    status: String,
+    finished: bool,
+}
+
+impl BuildTuiApp {
+    fn live(
+        package: &Package,
+        variant_index: Option<usize>,
+        install_path: String,
+        output_mode: BuildOutputMode,
+    ) -> Self {
+        let variant_label = variant_index
+            .map(|index| format!(" variant {}", index))
+            .unwrap_or_default();
+        let sections = [
+            BuildStep::Preparing,
+            BuildStep::Configuring,
+            BuildStep::Compiling,
+            BuildStep::Testing,
+            BuildStep::Packaging,
+            BuildStep::Installing,
+            BuildStep::Cleanup,
+        ]
+        .into_iter()
+        .map(|step| BuildOutputSection {
+            name: step_label(&step).to_string(),
+            body_lines: Vec::new(),
+            status: "queued".to_string(),
+            duration_ms: None,
+        })
+        .collect::<Vec<_>>();
+        let expanded = sections
+            .iter()
+            .map(|section| matches!(section.name.as_str(), "compiling" | "installing"))
+            .collect();
+
+        Self {
+            package_label: format!("{}{}", package_label(package), variant_label),
+            install_path,
+            sections,
+            selected: 0,
+            expanded,
+            output_mode,
+            status: "starting".to_string(),
+            finished: false,
+        }
+    }
+
+    fn on_event(&mut self, event: BuildEvent) {
+        match event.kind {
+            BuildEventKind::BuildStarted => {
+                self.status = event.message;
+            }
+            BuildEventKind::StepStarted => {
+                if let Some(step) = event.step {
+                    self.ensure_step(&step).status = "running".to_string();
+                }
+            }
+            BuildEventKind::StepOutput | BuildEventKind::StepError => {
+                if let Some(step) = event.step {
+                    if let Some(path) = event.message.strip_prefix("Created install directory: ") {
+                        self.install_path = path.to_string();
+                    }
+                    let section = self.ensure_step(&step);
+                    if !section.body_lines.contains(&event.message) {
+                        section.body_lines.push(event.message);
+                    }
+                }
+            }
+            BuildEventKind::StepFinished => {
+                if let Some(step) = event.step {
+                    let section = self.ensure_step(&step);
+                    section.status = if event.success.unwrap_or(false) {
+                        "ok".to_string()
+                    } else {
+                        "failed".to_string()
+                    };
+                    section.duration_ms = event.duration_ms;
+                }
+            }
+            BuildEventKind::BuildFinished => {
+                self.status = event.message;
+                self.finished = true;
+            }
+        }
+    }
+
+    fn ensure_step(&mut self, step: &BuildStep) -> &mut BuildOutputSection {
+        let name = step_label(step).to_string();
+        if let Some(index) = self
+            .sections
+            .iter()
+            .position(|section| section.name == name)
+        {
+            return &mut self.sections[index];
+        }
+
+        self.sections.push(BuildOutputSection {
+            name,
+            body_lines: Vec::new(),
+            status: "running".to_string(),
+            duration_ms: None,
+        });
+        self.expanded.push(false);
+        self.sections.last_mut().expect("section was just pushed")
+    }
+
+    fn next(&mut self) {
+        if self.sections.is_empty() {
+            return;
+        }
+        self.selected = (self.selected + 1).min(self.sections.len() - 1);
+    }
+
+    fn previous(&mut self) {
+        self.selected = self.selected.saturating_sub(1);
+    }
+
+    fn toggle_selected(&mut self) {
+        if let Some(expanded) = self.expanded.get_mut(self.selected) {
+            *expanded = !*expanded;
+        }
+    }
+
+    fn toggle_mode(&mut self) {
+        self.output_mode = match self.output_mode.effective() {
+            BuildOutputMode::Full => BuildOutputMode::Compact,
+            BuildOutputMode::Auto | BuildOutputMode::Compact => BuildOutputMode::Full,
+        };
+    }
+}
+
+fn draw_build_tui(frame: &mut ratatui::Frame<'_>, app: &BuildTuiApp) {
+    let area = frame.area();
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(6),
+            Constraint::Length(3),
+        ])
+        .split(area);
+
+    let title = Paragraph::new(vec![
+        Line::from(vec![
+            Span::styled(
+                "rez-build ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(&app.package_label),
+        ]),
+        Line::from(format!("{} | install: {}", app.status, app.install_path)),
+    ])
+    .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(title, vertical[0]);
+
+    let horizontal = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(28), Constraint::Min(20)])
+        .split(vertical[1]);
+
+    let items: Vec<ListItem> = app
+        .sections
+        .iter()
+        .enumerate()
+        .map(|(index, section)| {
+            let marker = if app.expanded.get(index).copied().unwrap_or(false) {
+                "[-]"
+            } else {
+                "[+]"
+            };
+            let duration = section
+                .duration_ms
+                .map(|duration| format!(" {duration}ms"))
+                .unwrap_or_default();
+            ListItem::new(format!(
+                "{marker} {:<11} {}{}",
+                section.name.to_ascii_lowercase(),
+                section.status,
+                duration
+            ))
+        })
+        .collect();
+    let mut state = ListState::default();
+    if !app.sections.is_empty() {
+        state.select(Some(app.selected));
+    }
+    let list = List::new(items)
+        .block(Block::default().title("steps").borders(Borders::ALL))
+        .highlight_style(Style::default().fg(Color::Black).bg(Color::Cyan));
+    frame.render_stateful_widget(list, horizontal[0], &mut state);
+
+    let log_lines = selected_tui_lines(app);
+    let logs = Paragraph::new(log_lines.join("\n"))
+        .block(Block::default().title("log").borders(Borders::ALL))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(logs, horizontal[1]);
+
+    let help_text = if app.finished {
+        "Up/Down: select  Enter: fold/unfold  c: compact/full  q: quit"
+    } else {
+        "Live build dashboard  Up/Down: select  Enter: fold/unfold  c: compact/full"
+    };
+    let help = Paragraph::new(help_text).block(Block::default().borders(Borders::ALL));
+    frame.render_widget(help, vertical[2]);
+}
+
+fn selected_tui_lines(app: &BuildTuiApp) -> Vec<String> {
+    let Some(section) = app.sections.get(app.selected) else {
+        return vec!["No build output".to_string()];
+    };
+    if !app.expanded.get(app.selected).copied().unwrap_or(false) {
+        return vec!["Section collapsed. Press Enter to expand.".to_string()];
+    }
+
+    match app.output_mode.effective() {
+        BuildOutputMode::Full => section.body_lines.clone(),
+        BuildOutputMode::Auto | BuildOutputMode::Compact => {
+            let mut lines: Vec<String> = section
+                .body_lines
+                .iter()
+                .filter(|line| should_show_build_line(line))
+                .cloned()
+                .collect();
+            let hidden = section
+                .body_lines
+                .iter()
+                .filter(|line| !should_show_build_line(line) && !is_quiet_build_line(line))
+                .count();
+            if hidden > 0 {
+                lines.push(format!("... {hidden} log line(s) hidden; press c for full"));
+            }
+            if lines.is_empty() {
+                lines.push("No important log lines in compact mode. Press c for full.".to_string());
+            }
+            lines
+        }
+    }
+}
+
+fn print_collapsible_lines<I, S>(
+    lines: I,
+    output_mode: BuildOutputMode,
+    compact_limit: usize,
+    item_name: &str,
+) where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let lines: Vec<String> = lines
+        .into_iter()
+        .map(|line| line.as_ref().to_string())
+        .collect();
+    let effective = output_mode.effective();
+    let visible_count = match effective {
+        BuildOutputMode::Full => lines.len(),
+        BuildOutputMode::Auto | BuildOutputMode::Compact => lines.len().min(compact_limit),
+    };
+
+    for line in lines.iter().take(visible_count) {
+        println!("{line}");
+    }
+
+    let hidden = lines.len().saturating_sub(visible_count);
+    if hidden > 0 {
+        println!("... {hidden} {item_name}(s) hidden; use --output full to expand");
+    }
+}
+
+fn print_build_success_summary(count: usize, term: &TermStyle) {
+    print_banner("Build Summary");
+    println!(
+        "{}",
+        term.ok(&format!("All {} build(s) were successful.", count))
+    );
+}
+
+struct BuildOutputSection {
+    name: String,
+    body_lines: Vec<String>,
+    status: String,
+    duration_ms: Option<u64>,
+}
+
+fn step_label(step: &BuildStep) -> &'static str {
+    match step {
+        BuildStep::Preparing => "preparing",
+        BuildStep::Configuring => "configuring",
+        BuildStep::Compiling => "compiling",
+        BuildStep::Testing => "testing",
+        BuildStep::Packaging => "packaging",
+        BuildStep::Installing => "installing",
+        BuildStep::Cleanup => "cleanup",
+    }
+}
+
+fn should_show_build_line(line: &str) -> bool {
+    line.contains("Builder:")
+        || line.starts_with("Invoking ")
+        || line.starts_with("Running build command:")
+        || line.contains("installed")
+        || line.contains("Copied ")
+        || line.contains("Created ")
+        || line.contains("Building ")
+        || line.contains("Processing ")
+        || line.contains("Successfully ")
+        || line.contains("Cleaning ")
+        || line.contains("Creating ")
+        || line.contains("Moving ")
+        || line.contains("ready")
+        || line.contains("skipped")
+}
+
+fn is_quiet_build_line(line: &str) -> bool {
+    matches!(
+        line.trim(),
+        "Tests completed"
+            | "Packaging completed"
+            | "Cleanup completed"
+            | "Configuration completed for script: rezbuild.py"
+    )
+}
+
+struct TermStyle {
+    color: bool,
+}
+
+impl TermStyle {
+    fn detect() -> Self {
+        Self {
+            color: std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none(),
+        }
+    }
+
+    fn step(&self, value: &str) -> String {
+        self.paint(value, "36")
+    }
+
+    fn ok(&self, value: &str) -> String {
+        self.paint(value, "32")
+    }
+
+    fn paint(&self, value: &str, code: &str) -> String {
+        if self.color {
+            format!("\x1b[{code}m{value}\x1b[0m")
+        } else {
+            value.to_string()
+        }
+    }
 }
 
 /// Get installation path

--- a/src/cli/commands/plugins.rs
+++ b/src/cli/commands/plugins.rs
@@ -60,6 +60,7 @@ pub fn execute(args: PluginsArgs) -> RezCoreResult<()> {
         println!(
             "Available plugin types: build_process, build_system, release_hook, release_vcs, shell"
         );
+        println!("Built-in build_system plugins: binary_archive, pypi");
         println!("Use 'rez plugins <package>' to list plugins for a specific package.");
         return Ok(());
     }
@@ -197,6 +198,7 @@ fn discover_build_plugins(package: &Package) -> RezCoreResult<Vec<PluginInfo>> {
         ("cmake", "CMake build system"),
         ("make", "Make build system"),
         ("python", "Python build system"),
+        ("pypi", "PyPI package installer"),
         ("pip", "Python pip installer"),
         ("setuptools", "Python setuptools"),
         ("poetry", "Python Poetry"),

--- a/src/cli/commands/test.rs
+++ b/src/cli/commands/test.rs
@@ -203,16 +203,7 @@ impl PackageTestRunner {
     fn extract_tests_from_package(&mut self, package: &rez_next_package::Package) {
         // Package.tests is HashMap<String, String> where value is the command
         for (test_name, command_str) in &package.tests {
-            let cmd = if command_str.contains(' ') {
-                // Multi-word command, split it
-                let parts: Vec<String> = command_str
-                    .split_whitespace()
-                    .map(|s| s.to_string())
-                    .collect();
-                TestCommand::List(parts)
-            } else {
-                TestCommand::String(command_str.clone())
-            };
+            let cmd = TestCommand::String(command_str.clone());
 
             self.test_definitions.insert(
                 test_name.clone(),

--- a/tests/cli_e2e_helpers.rs
+++ b/tests/cli_e2e_helpers.rs
@@ -13,6 +13,9 @@ pub fn rez_next_bin() -> PathBuf {
     if let Ok(path) = std::env::var("REZ_NEXT_E2E_BINARY") {
         return PathBuf::from(path);
     }
+    if let Some(path) = option_env!("CARGO_BIN_EXE_rez-next") {
+        return PathBuf::from(path);
+    }
     if let Ok(current_exe) = std::env::current_exe() {
         if let Some(debug_dir) = current_exe.parent().and_then(|deps_dir| deps_dir.parent()) {
             let candidate = debug_dir.join(if cfg!(windows) {

--- a/tests/cli_e2e_misc_tests.rs
+++ b/tests/cli_e2e_misc_tests.rs
@@ -6,6 +6,7 @@
 //! Extracted from cli_e2e_tests.rs (Cycle 140).
 
 use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[path = "cli_e2e_helpers.rs"]
@@ -23,6 +24,134 @@ macro_rules! skip_no_bin {
             return;
         }
     };
+}
+
+fn copy_dir_recursive(src: &Path, dest: &Path) {
+    fs::create_dir_all(dest).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let src_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+        if src_path.is_dir() {
+            copy_dir_recursive(&src_path, &dest_path);
+        } else {
+            fs::copy(src_path, dest_path).unwrap();
+        }
+    }
+}
+
+fn create_vx_artifact_files(source_dir: &Path) {
+    let dist_dir = source_dir.join("dist");
+    fs::create_dir_all(&dist_dir).unwrap();
+    let artifact = dist_dir.join("vx-artifact.zip");
+    let script = format!(
+        r##"
+import hashlib
+import pathlib
+import zipfile
+
+artifact = pathlib.Path(r"{artifact}")
+with zipfile.ZipFile(artifact, "w") as archive:
+    archive.writestr("bin/vx.cmd", "@echo off\r\necho vx cli-test\r\n")
+    archive.writestr("bin/vx", "#!/bin/sh\necho vx cli-test\n")
+sha256 = hashlib.sha256(artifact.read_bytes()).hexdigest()
+artifact.with_suffix(".sha256").write_text(sha256, encoding="utf-8")
+"##,
+        artifact = artifact.to_string_lossy()
+    );
+    let output = Command::new("python")
+        .arg("-c")
+        .arg(script)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to create vx cli artifact: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn create_pypi_sample_wheel(source_dir: &Path) -> PathBuf {
+    let dist_dir = source_dir.join("dist");
+    fs::create_dir_all(&dist_dir).unwrap();
+    let wheel = dist_dir.join("pypi_sample-1.0.0-py3-none-any.whl");
+    let script = format!(
+        r##"
+import pathlib
+import zipfile
+
+wheel = pathlib.Path(r"{wheel}")
+with zipfile.ZipFile(wheel, "w") as archive:
+    archive.writestr("pypi_sample/__init__.py", "VALUE = 'pypi-plugin-ok'\n")
+    archive.writestr(
+        "pypi_sample-1.0.0.dist-info/METADATA",
+        "Metadata-Version: 2.1\nName: pypi-sample\nVersion: 1.0.0\nSummary: rez-next pypi fixture\n",
+    )
+    archive.writestr(
+        "pypi_sample-1.0.0.dist-info/WHEEL",
+        "Wheel-Version: 1.0\nGenerator: rez-next-test\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+    )
+    archive.writestr("pypi_sample-1.0.0.dist-info/RECORD", "")
+"##,
+        wheel = wheel.to_string_lossy()
+    );
+    let output = Command::new("python")
+        .arg("-c")
+        .arg(script)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to create pypi sample wheel: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    wheel
+}
+
+fn vx_fixture_source() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples/build_plugins/extraction_vx")
+}
+
+fn pypi_fixture_source() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples/build_plugins/pypi_wheel")
+}
+
+fn build_deps_repo_source() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/build_deps_repo")
+}
+
+fn python_executable() -> String {
+    let output = Command::new("python")
+        .args(["-c", "import sys; print(sys.executable)"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to locate python executable: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn create_python_shim(repo: &Path) {
+    let bin_dir = repo.join("python").join("3.11.0").join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let python = python_executable();
+    if cfg!(windows) {
+        fs::write(
+            bin_dir.join("python.cmd"),
+            format!("@echo off\r\n\"{}\" %*\r\n", python),
+        )
+        .unwrap();
+    } else {
+        let shim = bin_dir.join("python");
+        fs::write(&shim, format!("#!/bin/sh\n\"{}\" \"$@\"\n", python)).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&shim, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
 }
 
 // ── depends ───────────────────────────────────────────────────────────────────
@@ -359,5 +488,161 @@ fn test_build_extra_args_separator_accepted() {
     assert!(
         !combined.trim().is_empty(),
         "build should produce output when given -- extra args: combined={combined}"
+    );
+}
+
+#[test]
+fn test_build_dot_vx_style_rez_package_with_cli_binary() {
+    skip_no_bin!();
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("vx_rez_package");
+    let package_repo = tmp.path().join("build_deps_repo");
+    copy_dir_recursive(&vx_fixture_source(), &source);
+    copy_dir_recursive(&build_deps_repo_source(), &package_repo);
+    create_python_shim(&package_repo);
+    create_vx_artifact_files(&source);
+
+    let out = Command::new(cli_e2e_helpers::rez_next_bin())
+        .args(["build", "."])
+        .current_dir(&source)
+        .env("REZ_PACKAGES_PATH", &package_repo)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert!(
+        out.status.success(),
+        "rez-next build . should build vx-style fixture\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let install_dir = source.join(".rez_build").join("vx").join("install");
+    assert!(
+        install_dir.join("bin").join("vx.cmd").exists(),
+        "build should install vx.cmd into {}",
+        install_dir.display()
+    );
+    assert!(
+        install_dir.join("bin").join("vx").exists(),
+        "build should install vx shell shim into {}",
+        install_dir.display()
+    );
+
+    let run = if cfg!(windows) {
+        Command::new("cmd")
+            .args([
+                "/C",
+                &install_dir.join("bin").join("vx.cmd").to_string_lossy(),
+            ])
+            .output()
+            .unwrap()
+    } else {
+        Command::new("sh")
+            .arg(install_dir.join("bin").join("vx"))
+            .output()
+            .unwrap()
+    };
+    assert!(
+        run.status.success(),
+        "installed vx command should execute: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run.stdout).trim(), "vx cli-test");
+
+    let test_out = Command::new(cli_e2e_helpers::rez_next_bin())
+        .args(["test", ".", "--inplace"])
+        .current_dir(&source)
+        .env("REZ_PACKAGES_PATH", &package_repo)
+        .output()
+        .unwrap();
+    let test_stdout = String::from_utf8_lossy(&test_out.stdout).to_string();
+    let test_stderr = String::from_utf8_lossy(&test_out.stderr).to_string();
+    assert!(
+        test_out.status.success(),
+        "rez-next test . should run vx fixture tests\nstdout: {test_stdout}\nstderr: {test_stderr}"
+    );
+    assert!(
+        test_stdout.contains("Passed") || test_stdout.contains("All tests passed"),
+        "test output should report passing tests: {test_stdout}"
+    );
+}
+
+#[test]
+fn test_build_dot_pypi_rez_package_with_cli_binary() {
+    skip_no_bin!();
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("pypi_rez_package");
+    let package_repo = tmp.path().join("build_deps_repo");
+    copy_dir_recursive(&pypi_fixture_source(), &source);
+    copy_dir_recursive(&build_deps_repo_source(), &package_repo);
+    create_python_shim(&package_repo);
+    create_pypi_sample_wheel(&source);
+
+    let out = Command::new(cli_e2e_helpers::rez_next_bin())
+        .args(["build", "."])
+        .current_dir(&source)
+        .env("REZ_PACKAGES_PATH", &package_repo)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert!(
+        out.status.success(),
+        "rez-next build . should build pypi fixture\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let install_dir = source
+        .join(".rez_build")
+        .join("pypi_sample")
+        .join("install");
+    assert!(
+        install_dir
+            .join("python")
+            .join("pypi_sample")
+            .join("__init__.py")
+            .exists(),
+        "pypi plugin should install importable package into {}",
+        install_dir.display()
+    );
+
+    let run = Command::new("python")
+        .arg("-c")
+        .arg("import pypi_sample; print(pypi_sample.VALUE)")
+        .env("PYTHONPATH", install_dir.join("python"))
+        .output()
+        .unwrap();
+    assert!(
+        run.status.success(),
+        "installed pypi package should import: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout).trim(),
+        "pypi-plugin-ok"
+    );
+}
+
+#[test]
+fn test_build_dot_vx_style_rez_package_fails_without_artifact() {
+    skip_no_bin!();
+    let tmp = tempfile::tempdir().unwrap();
+    let source = tmp.path().join("vx_rez_package");
+    copy_dir_recursive(&vx_fixture_source(), &source);
+    let _ = fs::remove_dir_all(source.join("dist"));
+
+    let out = Command::new(cli_e2e_helpers::rez_next_bin())
+        .args(["build", "."])
+        .current_dir(&source)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+
+    assert!(
+        !out.status.success(),
+        "build should fail when the configured artifact is missing\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("archive artifact does not exist") || stderr.contains("vx-artifact.zip"),
+        "failure should identify missing artifact\nstdout: {stdout}\nstderr: {stderr}"
     );
 }

--- a/tests/fixtures/build_deps_repo/python/3.11.0/package.py
+++ b/tests/fixtures/build_deps_repo/python/3.11.0/package.py
@@ -1,0 +1,12 @@
+"""Python standalone package fixture for build-environment resolution tests."""
+
+name = "python"
+version = "3.11.0"
+build_system = "binary_archive"
+tools = ["python"]
+
+
+def commands():
+    env.setenv("PYTHON_SENTINEL", "from-python-fixture")
+    env.setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+    env.PATH.prepend("{root}/bin")

--- a/tests/fixtures/build_deps_repo/python/3.11.0/rezbuild.py
+++ b/tests/fixtures/build_deps_repo/python/3.11.0/rezbuild.py
@@ -1,0 +1,130 @@
+#! /usr/bin/env python
+"""Build a Rez Python package from a python-build-standalone artifact.
+
+Tests pass a local artifact path via PYTHON_STANDALONE_ARTIFACT. Outside tests,
+this script can download an artifact URL selected for the current platform or
+provided via PYTHON_STANDALONE_URL.
+"""
+
+import hashlib
+import os
+import pathlib
+import shutil
+import sys
+import tarfile
+import tempfile
+import urllib.request
+import zipfile
+
+
+DEFAULT_RELEASE = "20260510"
+DEFAULT_VERSION = "3.11.14"
+
+
+def _platform_tag():
+    if sys.platform.startswith("win"):
+        return "x86_64-pc-windows-msvc"
+    if sys.platform == "darwin":
+        return "aarch64-apple-darwin" if os.uname().machine == "arm64" else "x86_64-apple-darwin"
+    return "x86_64-unknown-linux-gnu"
+
+
+def _default_url():
+    release = os.environ.get("PYTHON_STANDALONE_RELEASE", DEFAULT_RELEASE)
+    version = os.environ.get("PYTHON_STANDALONE_VERSION", DEFAULT_VERSION)
+    filename = (
+        f"cpython-{version}+{release}-{_platform_tag()}-install_only_stripped.tar.gz"
+    )
+    return (
+        "https://github.com/astral-sh/python-build-standalone/releases/download/"
+        f"{release}/{filename}"
+    )
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _copytree_contents(source, destination):
+    destination.mkdir(parents=True, exist_ok=True)
+    for child in source.iterdir():
+        target = destination / child.name
+        if child.is_dir():
+            if target.exists():
+                shutil.rmtree(target)
+            shutil.copytree(child, target)
+        else:
+            shutil.copy2(child, target)
+
+
+def _download(url, destination):
+    with urllib.request.urlopen(url) as response:
+        with open(destination, "wb") as stream:
+            shutil.copyfileobj(response, stream)
+
+
+def _artifact_path(work_dir):
+    local_artifact = os.environ.get("PYTHON_STANDALONE_ARTIFACT")
+    if local_artifact:
+        path = pathlib.Path(local_artifact)
+        if not path.is_file():
+            raise RuntimeError(f"python standalone artifact does not exist: {path}")
+        return path
+
+    url = os.environ.get("PYTHON_STANDALONE_URL", _default_url())
+    destination = work_dir / pathlib.PurePosixPath(url).name
+    print(f"downloading python standalone artifact: {url}")
+    _download(url, destination)
+    return destination
+
+
+def _extract(artifact, destination):
+    if zipfile.is_zipfile(artifact):
+        with zipfile.ZipFile(artifact) as archive:
+            archive.extractall(destination)
+        return
+
+    if tarfile.is_tarfile(artifact):
+        with tarfile.open(artifact) as archive:
+            archive.extractall(destination)
+        return
+
+    raise RuntimeError(f"unsupported python standalone artifact: {artifact}")
+
+
+def build():
+    install_path = os.environ.get("REZ_BUILD_INSTALL_PATH")
+    if not install_path:
+        raise RuntimeError("REZ_BUILD_INSTALL_PATH is required")
+
+    install_root = pathlib.Path(install_path)
+    expected_sha256 = os.environ.get("PYTHON_STANDALONE_SHA256")
+
+    with tempfile.TemporaryDirectory(prefix="python-standalone-rez-") as temp_root:
+        work_dir = pathlib.Path(temp_root)
+        artifact = _artifact_path(work_dir)
+        if expected_sha256 and _sha256(artifact) != expected_sha256:
+            raise RuntimeError("python standalone artifact sha256 mismatch")
+
+        extract_root = work_dir / "extract"
+        extract_root.mkdir()
+        _extract(artifact, extract_root)
+
+        payload = extract_root / "python" / "install"
+        if not payload.is_dir():
+            raise RuntimeError("artifact missing python/install payload")
+        _copytree_contents(payload, install_root)
+
+    print(f"installed python standalone to {install_root}")
+
+
+if __name__ == "__main__":
+    try:
+        build()
+    except Exception as exc:
+        print(f"python rezbuild failed: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/tests/fixtures/build_deps_repo/rez_builder/0.1.0/package.py
+++ b/tests/fixtures/build_deps_repo/rez_builder/0.1.0/package.py
@@ -1,0 +1,10 @@
+"""Minimal rez_builder-like package fixture used by vx build tests."""
+
+name = "rez_builder"
+version = "0.1.0"
+requires = ["python-3+"]
+
+
+def commands():
+    env.setenv("REZ_BUILDER_SENTINEL", "from-rez-builder-fixture")
+    env.setenv("REZ_BUILDER_MODULE_PATH", "{root}/python")

--- a/tests/fixtures/open_source_rez_packages/LICENSE
+++ b/tests/fixtures/open_source_rez_packages/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/fixtures/open_source_rez_packages/README.md
+++ b/tests/fixtures/open_source_rez_packages/README.md
@@ -1,0 +1,13 @@
+# Open Source Rez Packages Fixtures
+
+Selected package definitions from:
+
+https://github.com/UTS-AnimalLogicAcademy/open-source-rez-packages
+
+Upstream snapshot inspected at commit:
+
+09230ac01f135403907d8d35640d5e8e6a0615e5
+
+The upstream repository is MIT licensed. These fixtures intentionally keep a
+small offline subset of package definitions so tests do not depend on network
+access or perform real third-party source builds.

--- a/tests/fixtures/open_source_rez_packages/aces_container/1.0.2/package.py
+++ b/tests/fixtures/open_source_rez_packages/aces_container/1.0.2/package.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+name = 'aces_container'
+
+version = '1.0.3'
+
+private_build_requires = ['cmake-3', 'devtoolset-7+']
+
+requires = ['os-RedHatEnterprise-8.10+']
+
+def commands():
+    appendenv('LD_LIBRARY_PATH', '{root}/lib')
+    appendenv('LIBRARY_PATH', '{root}/lib')
+    appendenv('PKG_CONFIG_PATH', '{root}/lib/pkgconfig')
+    setenv('AcesContainer_ROOT', '{root}')
+    setenv('AcesContainer_DIR', '{root}/lib/CMake/AcesContainer')

--- a/tests/fixtures/pypi_rez_package/package.py
+++ b/tests/fixtures/pypi_rez_package/package.py
@@ -1,0 +1,17 @@
+"""PyPI-backed Rez package fixture for the built-in pypi plugin."""
+
+name = "pypi_sample"
+version = "1.0.0"
+description = "Fixture package installed from a pip-compatible wheel"
+build_system = "pypi"
+
+requires = ["python-3+"]
+build_requires = ["python-3+"]
+
+tests = {
+    "import": "python -c \"import pypi_sample; print(pypi_sample.VALUE)\"",
+}
+
+
+def commands():
+    env.PYTHONPATH.prepend("{root}/python")

--- a/tests/fixtures/vx_rez_package/package.py
+++ b/tests/fixtures/vx_rez_package/package.py
@@ -1,0 +1,18 @@
+"""Rez package fixture for vx-style binary extraction builds."""
+
+name = "vx"
+version = "0.0.1"
+description = "Universal Development Tool Manager test fixture."
+build_system = "binary_archive"
+tools = ["vx"]
+requires = ["python-3+"]
+build_requires = ["python-3+"]
+private_build_requires = ["rez_builder-0"]
+tests = {
+    "artifact": "python tests/check_artifact.py",
+    "zipfile": "python tests/check_zipfile.py",
+}
+
+
+def commands():
+    env.PATH.prepend("{root}/bin")

--- a/tests/fixtures/vx_rez_package/rezbuild.py
+++ b/tests/fixtures/vx_rez_package/rezbuild.py
@@ -1,0 +1,99 @@
+#! /usr/bin/env python
+"""Offline vx-style Rez build fixture.
+
+The production vx Rez package downloads a prebuilt artifact, verifies it,
+extracts it, and moves the extracted payload into the Rez install root. This
+fixture follows the same shape without network access: tests provide a local
+zip path and sha256 via environment variables.
+"""
+
+import hashlib
+import os
+import shutil
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _copytree_contents(source, destination):
+    destination.mkdir(parents=True, exist_ok=True)
+    for child in source.iterdir():
+        target = destination / child.name
+        if child.is_dir():
+            if target.exists():
+                shutil.rmtree(target)
+            shutil.copytree(child, target)
+        else:
+            shutil.copy2(child, target)
+
+
+def _require_env(name):
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"missing required build dependency environment variable: {name}")
+    return value
+
+
+def _assert_build_dependency_environment():
+    _require_env("PYTHON_ROOT")
+    _require_env("REZ_BUILDER_ROOT")
+    if os.environ.get("PYTHON_SENTINEL") != "from-python-fixture":
+        raise RuntimeError("python fixture environment was not applied")
+    if os.environ.get("REZ_BUILDER_SENTINEL") != "from-rez-builder-fixture":
+        raise RuntimeError("rez_builder fixture environment was not applied")
+
+
+def build():
+    _assert_build_dependency_environment()
+
+    source_root = Path(__file__).resolve().parent
+    artifact = os.environ.get("VX_REZ_TEST_ARTIFACT")
+    expected_sha256 = os.environ.get("VX_REZ_TEST_SHA256")
+    install_path = os.environ.get("REZ_BUILD_INSTALL_PATH")
+
+    if not artifact:
+        artifact = str(source_root / "dist" / "vx-artifact.zip")
+    if not expected_sha256:
+        checksum_file = source_root / "dist" / "vx-artifact.sha256"
+        if not checksum_file.is_file():
+            raise RuntimeError("VX_REZ_TEST_SHA256 or dist/vx-artifact.sha256 is required")
+        expected_sha256 = checksum_file.read_text(encoding="utf-8").strip()
+    if not install_path:
+        raise RuntimeError("REZ_BUILD_INSTALL_PATH is required")
+
+    artifact_path = Path(artifact)
+    if not artifact_path.is_file():
+        raise RuntimeError(f"artifact does not exist: {artifact_path}")
+
+    actual_sha256 = _sha256(artifact_path)
+    if actual_sha256 != expected_sha256:
+        raise RuntimeError(
+            f"artifact sha256 mismatch: expected {expected_sha256}, got {actual_sha256}"
+        )
+
+    install_root = Path(install_path)
+    with tempfile.TemporaryDirectory(prefix="vx-rez-extract-") as temp_root:
+        extract_root = Path(temp_root) / "extract"
+        extract_root.mkdir()
+        with zipfile.ZipFile(artifact_path) as archive:
+            archive.extractall(extract_root)
+        _copytree_contents(extract_root, install_root)
+
+    print(f"installed vx artifact to {install_root}")
+
+
+if __name__ == "__main__":
+    try:
+        build()
+    except Exception as exc:
+        print(f"vx rezbuild failed: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/tests/fixtures/vx_rez_package/tests/check_artifact.py
+++ b/tests/fixtures/vx_rez_package/tests/check_artifact.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+assert Path("dist/vx-artifact.zip").is_file()

--- a/tests/fixtures/vx_rez_package/tests/check_zipfile.py
+++ b/tests/fixtures/vx_rez_package/tests/check_zipfile.py
@@ -1,0 +1,3 @@
+import zipfile
+
+assert zipfile.is_zipfile("dist/vx-artifact.zip")

--- a/tests/open_source_rez_packages_dataset_tests.rs
+++ b/tests/open_source_rez_packages_dataset_tests.rs
@@ -1,0 +1,521 @@
+//! Offline fixture tests for UTS-AnimalLogicAcademy/open-source-rez-packages.
+
+use rez_next_build::{BuildConfig, BuildManager, BuildRequest};
+use rez_next_context::{ContextConfig, ContextStatus, EnvironmentManager, ResolvedContext};
+use rez_next_package::Package;
+use rez_next_package::PackageRequirement;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/open_source_rez_packages")
+}
+
+fn aces_container_source() -> PathBuf {
+    fixture_root().join("aces_container").join("1.0.2")
+}
+
+fn make_build_manager(temp_dir: &TempDir) -> BuildManager {
+    let config = BuildConfig {
+        build_dir: temp_dir.path().join("build"),
+        temp_dir: temp_dir.path().join("tmp"),
+        keep_artifacts: true,
+        ..BuildConfig::default()
+    };
+    BuildManager::with_config(config)
+}
+
+async fn run_single_build(
+    package: Package,
+    source_dir: PathBuf,
+    temp_dir: &TempDir,
+) -> rez_next_build::BuildResult {
+    let mut manager = make_build_manager(temp_dir);
+    let request = BuildRequest::new(package, None, source_dir);
+    let build_ids = manager.start_build(request).await.unwrap();
+    assert_eq!(build_ids.len(), 1);
+    manager.wait_for_build(&build_ids[0]).await.unwrap()
+}
+
+async fn run_single_build_with_context(
+    package: Package,
+    source_dir: PathBuf,
+    temp_dir: &TempDir,
+    context: ResolvedContext,
+) -> rez_next_build::BuildResult {
+    let mut manager = make_build_manager(temp_dir);
+    let request = BuildRequest::new(package, Some(context), source_dir);
+    let build_ids = manager.start_build(request).await.unwrap();
+    assert_eq!(build_ids.len(), 1);
+    manager.wait_for_build(&build_ids[0]).await.unwrap()
+}
+
+fn copy_fixture_dir(src: &Path, dest: &Path) {
+    std::fs::create_dir_all(dest).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let src_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+        if src_path.is_dir() {
+            copy_fixture_dir(&src_path, &dest_path);
+        } else {
+            std::fs::copy(&src_path, &dest_path).unwrap();
+        }
+    }
+}
+
+fn vx_fixture_source() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/vx_rez_package")
+}
+
+fn build_deps_repo_source() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/build_deps_repo")
+}
+
+fn python_executable() -> String {
+    let output = Command::new("python")
+        .args(["-c", "import sys; print(sys.executable)"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to locate python executable: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn create_python_shim(repo: &Path) {
+    let bin_dir = repo.join("python").join("3.11.0").join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    let python = python_executable();
+    if cfg!(windows) {
+        std::fs::write(
+            bin_dir.join("python.cmd"),
+            format!("@echo off\r\n\"{}\" %*\r\n", python),
+        )
+        .unwrap();
+    } else {
+        let shim = bin_dir.join("python");
+        std::fs::write(&shim, format!("#!/bin/sh\n\"{}\" \"$@\"\n", python)).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+}
+
+fn create_bootstrap_python_bin(temp_dir: &TempDir) -> PathBuf {
+    let bin_dir = temp_dir.path().join("bootstrap_python").join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    let python = python_executable();
+    if cfg!(windows) {
+        std::fs::write(
+            bin_dir.join("python.cmd"),
+            format!("@echo off\r\n\"{}\" %*\r\n", python),
+        )
+        .unwrap();
+    } else {
+        let shim = bin_dir.join("python");
+        std::fs::write(&shim, format!("#!/bin/sh\n\"{}\" \"$@\"\n", python)).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+    bin_dir
+}
+
+fn create_python_standalone_artifact(temp_dir: &TempDir) -> (PathBuf, String) {
+    let artifact = temp_dir.path().join("python-standalone.tar.gz");
+    let script = format!(
+        r##"
+import hashlib
+import pathlib
+import tarfile
+import tempfile
+
+artifact = pathlib.Path(r"{artifact}")
+with tempfile.TemporaryDirectory() as tmp:
+    root = pathlib.Path(tmp) / "python" / "install" / "bin"
+    root.mkdir(parents=True)
+    (root / "python.cmd").write_text("@echo off\r\necho python standalone fixture\r\n", encoding="utf-8")
+    (root / "python").write_text("#!/bin/sh\necho python standalone fixture\n", encoding="utf-8")
+    with tarfile.open(artifact, "w:gz") as archive:
+        archive.add(pathlib.Path(tmp) / "python", arcname="python")
+print(hashlib.sha256(artifact.read_bytes()).hexdigest())
+"##,
+        artifact = artifact.to_string_lossy()
+    );
+    let output = Command::new("python")
+        .arg("-c")
+        .arg(script)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to create python standalone artifact: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let sha256 = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (artifact, sha256)
+}
+
+async fn vx_build_context(temp_dir: &TempDir) -> ResolvedContext {
+    let repo = temp_dir.path().join("build_deps_repo_context");
+    copy_fixture_dir(&build_deps_repo_source(), &repo);
+    create_python_shim(&repo);
+    let python = Package::from_path(repo.join("python").join("3.11.0")).unwrap();
+    let rez_builder = Package::from_path(repo.join("rez_builder").join("0.1.0")).unwrap();
+    let mut context = ResolvedContext::from_requirements(vec![
+        PackageRequirement::parse("python-3+").unwrap(),
+        PackageRequirement::parse("rez_builder-0").unwrap(),
+    ]);
+    context.resolved_packages = vec![python, rez_builder];
+    context.status = ContextStatus::Resolved;
+
+    let manager = EnvironmentManager::new(ContextConfig {
+        inherit_parent_env: false,
+        ..Default::default()
+    });
+    context.environment_vars = manager
+        .generate_environment(&context.resolved_packages)
+        .await
+        .unwrap();
+    context
+}
+
+async fn python_build_context(temp_dir: &TempDir) -> ResolvedContext {
+    let repo = temp_dir.path().join("python_build_deps_repo_context");
+    copy_fixture_dir(&build_deps_repo_source(), &repo);
+    create_python_shim(&repo);
+    let python = Package::from_path(repo.join("python").join("3.11.0")).unwrap();
+    let mut context =
+        ResolvedContext::from_requirements(vec![PackageRequirement::parse("python-3+").unwrap()]);
+    context.resolved_packages = vec![python];
+    context.status = ContextStatus::Resolved;
+
+    let manager = EnvironmentManager::new(ContextConfig {
+        inherit_parent_env: false,
+        ..Default::default()
+    });
+    context.environment_vars = manager
+        .generate_environment(&context.resolved_packages)
+        .await
+        .unwrap();
+    context
+}
+
+fn create_vx_artifact(temp_dir: &TempDir) -> (PathBuf, String) {
+    let artifact = temp_dir.path().join("vx-artifact.zip");
+    let script = format!(
+        r##"
+import hashlib
+import pathlib
+import zipfile
+
+artifact = pathlib.Path(r"{artifact}")
+artifact.parent.mkdir(parents=True, exist_ok=True)
+with zipfile.ZipFile(artifact, "w") as archive:
+    archive.writestr("bin/vx.cmd", "@echo off\r\necho vx 0.0.1-test\r\n")
+    archive.writestr("bin/vx", "#!/bin/sh\necho vx 0.0.1-test\n")
+print(hashlib.sha256(artifact.read_bytes()).hexdigest())
+"##,
+        artifact = artifact.to_string_lossy()
+    );
+    let output = Command::new("python")
+        .arg("-c")
+        .arg(script)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to create vx artifact: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let sha256 = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (artifact, sha256)
+}
+
+async fn run_vx_build(
+    package: Package,
+    source_dir: PathBuf,
+    temp_dir: &TempDir,
+    artifact: &Path,
+    sha256: &str,
+) -> rez_next_build::BuildResult {
+    let mut manager = make_build_manager(temp_dir);
+    let mut request =
+        BuildRequest::new(package, Some(vx_build_context(temp_dir).await), source_dir);
+    request.options.env_vars.insert(
+        "REZ_BINARY_ARCHIVE_ARTIFACT".to_string(),
+        artifact.to_string_lossy().to_string(),
+    );
+    request
+        .options
+        .env_vars
+        .insert("REZ_BINARY_ARCHIVE_SHA256".to_string(), sha256.to_string());
+
+    let build_ids = manager.start_build(request).await.unwrap();
+    assert_eq!(build_ids.len(), 1);
+    manager.wait_for_build(&build_ids[0]).await.unwrap()
+}
+
+#[test]
+fn parses_real_open_source_rez_package_fixture() {
+    let source = aces_container_source();
+    let package = Package::from_path(&source).unwrap();
+
+    assert_eq!(package.name, "aces_container");
+    assert_eq!(
+        package.version.as_ref().map(|version| version.as_str()),
+        Some("1.0.3")
+    );
+    assert!(
+        package
+            .requires
+            .contains(&"os-RedHatEnterprise-8.10+".to_string())
+    );
+    assert!(
+        package
+            .private_build_requires
+            .contains(&"cmake-3".to_string())
+    );
+    assert_eq!(package.root(), Some(source.to_string_lossy().to_string()));
+}
+
+#[test]
+fn real_open_source_rez_package_uses_actual_root_in_environment() {
+    let source = aces_container_source();
+    let package = Package::from_path(&source).unwrap();
+    let manager = EnvironmentManager::new(ContextConfig {
+        inherit_parent_env: false,
+        ..Default::default()
+    });
+
+    let env = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(manager.generate_environment(&[package]))
+        .unwrap();
+
+    assert_eq!(
+        env.get("ACES_CONTAINER_ROOT"),
+        Some(&source.to_string_lossy().to_string())
+    );
+}
+
+#[tokio::test]
+async fn builds_real_open_source_rez_package_fixture_successfully() {
+    let source = aces_container_source();
+    let package = Package::from_path(&source).unwrap();
+    let temp_dir = TempDir::new().unwrap();
+
+    let result = run_single_build(package, source, &temp_dir).await;
+
+    assert!(result.success, "build should succeed: {}", result.errors);
+    assert!(
+        result.artifacts.install_dir.join("package.py").exists(),
+        "copy-only build should install the package definition"
+    );
+}
+
+#[tokio::test]
+async fn builds_python_standalone_package_from_artifact() {
+    let temp_dir = TempDir::new().unwrap();
+    let source = temp_dir.path().join("python_rez_package");
+    copy_fixture_dir(
+        &build_deps_repo_source().join("python").join("3.11.0"),
+        &source,
+    );
+    let (artifact, sha256) = create_python_standalone_artifact(&temp_dir);
+    let package = Package::from_path(&source).unwrap();
+    let mut manager = make_build_manager(&temp_dir);
+    let mut request = BuildRequest::new(package, None, source);
+    request.options.env_vars.insert(
+        "REZ_BINARY_ARCHIVE_ARTIFACT".to_string(),
+        artifact.to_string_lossy().to_string(),
+    );
+    request.options.env_vars.insert(
+        "REZ_BINARY_ARCHIVE_PAYLOAD_PREFIX".to_string(),
+        "python/install".to_string(),
+    );
+    request
+        .options
+        .env_vars
+        .insert("REZ_BINARY_ARCHIVE_SHA256".to_string(), sha256);
+    request.options.env_vars.insert(
+        "PATH".to_string(),
+        create_bootstrap_python_bin(&temp_dir)
+            .to_string_lossy()
+            .to_string(),
+    );
+    request
+        .options
+        .env_vars
+        .insert("PATHEXT".to_string(), ".COM;.EXE;.BAT;.CMD".to_string());
+
+    let build_ids = manager.start_build(request).await.unwrap();
+    assert_eq!(build_ids.len(), 1);
+    let result = manager.wait_for_build(&build_ids[0]).await.unwrap();
+
+    assert!(
+        result.success,
+        "python standalone build should succeed: {}",
+        result.errors
+    );
+    assert!(
+        result
+            .artifacts
+            .install_dir
+            .join("bin")
+            .join(if cfg!(windows) {
+                "python.cmd"
+            } else {
+                "python"
+            })
+            .exists(),
+        "python standalone payload should be installed"
+    );
+}
+
+#[tokio::test]
+async fn build_failure_reports_step_command_exit_code_and_stderr() {
+    let fixture_source = aces_container_source();
+    let temp_dir = TempDir::new().unwrap();
+    let source = temp_dir.path().join("aces_container_failure");
+    copy_fixture_dir(&fixture_source, &source);
+    std::fs::write(
+        source.join("rezbuild.py"),
+        r#"
+import sys
+
+print("OSRP_FIXTURE_SENTINEL: missing cmake package", file=sys.stderr)
+sys.exit(1)
+"#,
+    )
+    .unwrap();
+
+    let package = Package::from_path(&source).unwrap();
+    let result = run_single_build_with_context(
+        package,
+        source,
+        &temp_dir,
+        python_build_context(&temp_dir).await,
+    )
+    .await;
+
+    assert!(!result.success, "failing rezbuild.py should fail the build");
+    assert!(
+        result.errors.contains("Installing Errors"),
+        "{}",
+        result.errors
+    );
+    assert!(
+        result.errors.contains("Command failed with exit code 1"),
+        "{}",
+        result.errors
+    );
+    assert!(result.errors.contains("rezbuild.py"), "{}", result.errors);
+    assert!(
+        result
+            .errors
+            .contains("OSRP_FIXTURE_SENTINEL: missing cmake package"),
+        "{}",
+        result.errors
+    );
+}
+
+#[tokio::test]
+async fn builds_vx_style_executable_rez_package_from_local_artifact() {
+    let temp_dir = TempDir::new().unwrap();
+    let source = temp_dir.path().join("vx_rez_package");
+    copy_fixture_dir(&vx_fixture_source(), &source);
+    let (artifact, sha256) = create_vx_artifact(&temp_dir);
+    let package = Package::from_path(&source).unwrap();
+
+    let result = run_vx_build(package, source, &temp_dir, &artifact, &sha256).await;
+
+    assert!(
+        result.success,
+        "vx-style build should succeed: {}",
+        result.errors
+    );
+    assert!(
+        result
+            .artifacts
+            .install_dir
+            .join("bin")
+            .join("vx.cmd")
+            .exists()
+    );
+    assert!(result.artifacts.install_dir.join("bin").join("vx").exists());
+
+    let output = if cfg!(windows) {
+        Command::new("cmd")
+            .args([
+                "/C",
+                &result
+                    .artifacts
+                    .install_dir
+                    .join("bin")
+                    .join("vx.cmd")
+                    .to_string_lossy(),
+            ])
+            .output()
+            .unwrap()
+    } else {
+        Command::new("sh")
+            .arg(result.artifacts.install_dir.join("bin").join("vx"))
+            .output()
+            .unwrap()
+    };
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "vx 0.0.1-test"
+    );
+}
+
+#[test]
+fn vx_style_package_exposes_tests_field() {
+    let package = Package::from_path(vx_fixture_source()).unwrap();
+
+    assert_eq!(package.requires, vec!["python-3+"]);
+    assert_eq!(package.build_requires, vec!["python-3+"]);
+    assert_eq!(package.private_build_requires, vec!["rez_builder-0"]);
+    assert_eq!(
+        package.tests.get("artifact").map(String::as_str),
+        Some("python tests/check_artifact.py")
+    );
+    assert_eq!(
+        package.tests.get("zipfile").map(String::as_str),
+        Some("python tests/check_zipfile.py")
+    );
+}
+
+#[tokio::test]
+async fn vx_style_rezbuild_reports_checksum_mismatch_precisely() {
+    let temp_dir = TempDir::new().unwrap();
+    let source = temp_dir.path().join("vx_rez_package");
+    copy_fixture_dir(&vx_fixture_source(), &source);
+    let (artifact, _sha256) = create_vx_artifact(&temp_dir);
+    let package = Package::from_path(&source).unwrap();
+
+    let result = run_vx_build(package, source, &temp_dir, &artifact, "bad-sha256").await;
+
+    assert!(!result.success, "checksum mismatch should fail the build");
+    assert!(
+        result.errors.contains("Installing Errors"),
+        "{}",
+        result.errors
+    );
+    assert!(
+        result.errors.contains("binary archive sha256 mismatch"),
+        "{}",
+        result.errors
+    );
+}

--- a/tests/real_repo_context_tests.rs
+++ b/tests/real_repo_context_tests.rs
@@ -59,6 +59,46 @@ fn test_env_context_has_rez_variables() {
 }
 
 #[test]
+fn test_env_generation_uses_actual_unpacked_repo_root() {
+    use rez_next_context::{ContextConfig, EnvironmentManager};
+
+    let tmp = TempDir::new().unwrap();
+    let repo_dir = tmp
+        .path()
+        .join("vx")
+        .join("cache")
+        .join("unpacked")
+        .join("packages");
+    create_package(
+        &repo_dir,
+        "python",
+        "3.11.0",
+        &[],
+        &["python"],
+        Some("env.setenv('PYTHON_HOME', '{root}')"),
+    );
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let simple_repo = SimpleRepository::new(repo_dir.clone(), "vx-cache".to_string());
+    let packages = rt.block_on(simple_repo.find_packages("python")).unwrap();
+    assert_eq!(packages.len(), 1);
+
+    let env_manager = EnvironmentManager::new(ContextConfig {
+        inherit_parent_env: false,
+        ..Default::default()
+    });
+    let package_values: Vec<Package> = packages.iter().map(|p| (**p).clone()).collect();
+    let env_vars = rt
+        .block_on(env_manager.generate_environment(&package_values))
+        .unwrap();
+
+    let expected_root = repo_dir.join("python").join("3.11.0");
+    let expected_root = expected_root.to_string_lossy().to_string();
+    assert_eq!(env_vars.get("PYTHON_ROOT"), Some(&expected_root));
+    assert_eq!(env_vars.get("PYTHON_HOME"), Some(&expected_root));
+}
+
+#[test]
 fn test_env_context_path_prepend() {
     let tmp = TempDir::new().unwrap();
     let repo_dir = tmp.path().to_path_buf();


### PR DESCRIPTION
## Summary

- add live `BuildEvent` streaming for build lifecycle, step output, and step errors
- add reusable extraction and PyPI-style build plugin examples plus Python helper APIs
- make build output Rez-style with compact/full modes and a Ratatui live dashboard
- add realistic fixtures and CLI tests for build deps, package roots, isolated env, and open-source Rez package data

## Validation

- `vx cargo fmt --all --check`
- `vx cargo build --bin rez-next`
- `vx cargo test -p rez-next-build test_build_manager_emits_live_build_events`
- `vx cargo test --test cli_e2e_misc_tests`
- `G:\PycharmProjects\github\rez-next\target\debug\rez-next.exe build . --output compact` from `examples\build_plugins\extraction_vx`
