### PR TITLE
docs: add llms.txt/llms-full.txt + update project documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,11 +7,11 @@
 rez-next is a **high-performance Rust rewrite** of the [Rez](https://github.com/AcademySoftwareFoundation/rez) package manager with Python bindings. It provides drop-in compatibility for most common Rez workflows while delivering significantly better performance.
 
 **Key facts for agents:**
-- Language: Rust (core) + Python (bindings via PyO3)
-- Build system: Cargo workspace + Maturin (Python)
-- Current version: 0.3.1
+- Language: Rust 2024 edition (MSRV 1.95) + Python 3.8+ bindings (PyO3 abi3)
+- Build system: Cargo workspace (20 crates) + Maturin for Python
+- Current version: 0.3.4
 - License: Apache 2.0
-- Status: Many workflows work with `import rez_next`, but **not yet a seamless drop-in** for every API surface
+- Status: Many workflows work with `import rez_next as rez`, but **not yet a seamless drop-in** for every API surface
 
 ## Quick Start
 
@@ -31,6 +31,8 @@ pkg = rez.get_latest_package("python")
 ### For AI Agents (this file is the primary entry point)
 - **CLAUDE.md** → Anthropic Claude-specific guidance (references this file)
 - **GEMINI.md** → Google Gemini-specific guidance (references this file)
+- **llms.txt** → AI-friendly concise usage index (Python submodules, crate map, quick commands)
+- **llms-full.txt** → Complete API reference (Rust + Python + CLI + benchmarks)
 
 ### For Humans
 - **README.md** → Project overview, installation, quick start
@@ -46,18 +48,20 @@ pkg = rez.get_latest_package("python")
 ### Reference
 - **CHANGELOG.md** → Release history
 - **SECURITY.md** → Security policy
-- **CLEANUP_TODO.md** → Technical debt tracker (internal)
 
 ## Architecture (Simplified)
 
 ```
 rez-next/                          # Monorepo root
-├── crates/                        # Rust crates (13 total)
+├── crates/                        # Rust crates (20 total)
 │   ├── rez-next-common/           # Shared types, errors, config
+│   ├── rez-next-config/           # Config loading & validation
 │   ├── rez-next-version/          # Version parsing (state machine)
-│   ├── rez-next-package/         # Package definition, package.py parser
-│   ├── rez-next-solver/          # Dependency solver (A* + backtracking)
-│   ├── rez-next-repository/      # Repository scanning, caching
+│   ├── rez-next-package/          # Package definition, package.py parser
+│   ├── rez-next-package-cache/    # Package payload caching
+│   ├── rez-next-package-filter/   # Package filter (glob, regex, range rules)
+│   ├── rez-next-solver/           # Dependency solver (A* + backtracking)
+│   ├── rez-next-repository/       # Repository scanning, caching
 │   ├── rez-next-context/         # Resolved contexts, Rex integration
 │   ├── rez-next-build/           # Build system integration
 │   ├── rez-next-cache/           # Multi-level caching
@@ -65,6 +69,10 @@ rez-next/                          # Monorepo root
 │   ├── rez-next-suites/          # Suite management
 │   ├── rez-next-bind/            # Bind system tools
 │   ├── rez-next-search/          # Package search
+│   ├── rez-next-explicit/        # Explicit package lists
+│   ├── rez-next-serialise/       # Serialization support
+│   ├── rez-next-release-hook/    # Release hooks
+│   ├── rez-next-util/            # Utility functions
 │   └── rez-next-python/          # Python bindings (PyO3)
 ├── src/                           # Rust CLI binary
 ├── tests/                         # Integration tests
@@ -100,8 +108,12 @@ vx just bench
 
 ### 3. Python Integration Testing
 ```bash
-maturin develop --release
-pytest
+# Build wheel + run tests (recommended)
+vx just py-build
+vx just py-test
+
+# Full Python CI
+vx just py-ci
 ```
 
 ### 4. Release Process
@@ -172,7 +184,7 @@ result = diff_contexts(["python-3.9"], ["python-3.11", "maya-2024"])
 
 ⚠️ **Not all Rez features are implemented** — check coverage before suggesting code changes
 
-⚠️ **Python bindings are partial** — `rez-next-python` has 18 submodules, not full Rez coverage
+⚠️ **Python bindings are partial** — `rez-next-python` has 37 submodules, not full Rez coverage
 
 ⚠️ **Breaking changes possible** — pre-1.0 project, API may change
 
@@ -184,4 +196,4 @@ result = diff_contexts(["python-3.9"], ["python-3.11", "maya-2024"])
 
 ---
 
-**For AI agents:** This file is your starting point. Follow links to `llms.txt` for API details, or `docs/` for human-oriented guides. When in doubt, check `python-integration.md` for feature coverage before suggesting implementations.
+**For AI agents:** This file is your progressive disclosure map. For concise API reference, see [llms.txt](./llms.txt). For complete API details, see [llms-full.txt](./llms-full.txt). For human-oriented guides, see [docs/](./docs/). When in doubt, check `docs/python-integration.md` for feature coverage before suggesting implementations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Read [AGENTS.md](./AGENTS.md) to understand:
 - Common tasks and how to approach them
 
 ### 2. Key Principles
-- **Progressive disclosure**: AGENTS.md → llms.txt → llms-full.txt → docs/
+- **Progressive disclosure**: AGENTS.md → llms.txt (concise) → llms-full.txt (full API) → docs/ (human guides)
 - **Check coverage**: Not all Rez APIs are implemented; verify before suggesting code
 - **Use vx**: Tool management via `vx` (see `vx.toml`)
 - **Run CI early**: `vx just ci` before submitting changes
@@ -44,7 +44,7 @@ use rez_next_package::Package;
 
 When updating documentation:
 1. Update AGENTS.md if project structure changes
-2. Update llms.txt if AI-facing API changes
+2. Update llms.txt if AI-facing usage index changes
 3. Update llms-full.txt for detailed API changes
 4. Update docs/*.md for human-facing changes
 5. Update README.md for user-facing changes

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -14,7 +14,7 @@ Read [AGENTS.md](./AGENTS.md) to understand:
 - Common tasks and how to approach them
 
 ### 2. Key Principles
-- **Progressive disclosure**: AGENTS.md → llms.txt → llms-full.txt → docs/
+- **Progressive disclosure**: AGENTS.md → llms.txt (concise) → llms-full.txt (full API) → docs/ (human guides)
 - **Check coverage**: Not all Rez APIs are implemented; verify before suggesting code
 - **Use vx**: Tool management via `vx` (see `vx.toml`)
 - **Run CI early**: `vx just ci` before submitting changes

--- a/docs/python-integration.md
+++ b/docs/python-integration.md
@@ -38,6 +38,7 @@ rez_next/
 |-----------|----------------|---------------|--------|
 | `rez_next.version` | `rez.vendor.version` | Version parsing, comparison, ranges | ✅ Stable |
 | `rez_next.packages_` | `rez.packages_` | Package iteration, queries, copy/move/remove | ✅ Stable |
+| `rez_next.packages` | `rez.packages` | Package object model | ✅ Stable |
 | `rez_next.resolved_context` | `rez.resolved_context` | Dependency resolution, context management | ✅ Stable |
 | `rez_next.suite` | `rez.suite` | Suite creation and tool-chain management | ✅ Stable |
 | `rez_next.config` | `rez.config` | Configuration reading | ✅ Stable |
@@ -45,6 +46,7 @@ rez_next/
 | `rez_next.shell` | `rez.shells` | Shell script generation (bash/zsh/fish/PowerShell/cmd) | ✅ Stable |
 | `rez_next.rex` | `rez.rex` | Rex command-language interpreter | ✅ Stable |
 | `rez_next.build_` | `rez.build_` | Package build system integration | ✅ Stable |
+| `rez_next.build_plugins` | `rez.build_plugins` | Build plugins | ✅ Stable |
 | `rez_next.release` | `rez.release` | Package release workflow | ✅ Stable |
 | `rez_next.bind` | `rez.bind` | Bind system tools as rez packages | ✅ Stable |
 | `rez_next.pip` | `rez.pip` | Convert pip packages to rez packages | ✅ Stable |
@@ -61,25 +63,16 @@ rez_next/
 | `rez_next.data` | `rez.data` | Built-in data resources | ✅ Stable |
 | `rez_next.cli` | `rez.cli` | CLI entry-points (programmatic invocation) | ✅ Stable |
 | `rez_next.exceptions` | `rez.exceptions` | Exception hierarchy | ✅ Stable |
-| `rez_next.utils.resources` | `rez.utils.resources` | Resource loading utilities | ✅ Stable |
+| `rez_next.deprecations` | `rez.utils.deprecations` | Deprecation warnings | ✅ Stable |
 | `rez_next.package_cache` | `rez.package_cache` | Package payload caching | ✅ Stable |
+| `rez_next.package_help` | `rez.package_help` | Package help | ✅ Stable |
+| `rez_next.package_search` | `rez.package_search` | Package search API | ✅ Stable |
+| `rez_next.package_remove` | `rez.package_remove` | Package removal | ✅ Stable |
 | `rez_next.solver_` | `rez.solver` | Dependency solver (partial) | ✅ Stable |
-| `rez_next.package_filter` | `rez.package_filter` | Package filtering | ✅ Stable |
-| `rez_next.package_test` | `rez.package_test` | Package testing | ✅ Stable |
-| `rez_next.command` | `rez.command` | Command utilities | ✅ Stable |
-| `rez_next.env` | `rez.env` | Environment creation and activation | ✅ Stable |
-| `rez_next.source` | `rez.source` | Context activation script generation | ✅ Stable |
-| `rez_next.bundles` | `rez.bundles` | Context bundling (offline use) | ✅ Stable |
-| `rez_next.forward` | `rez.forward` | Shell forward-compatibility scripts | ✅ Stable |
-| `rez_next.search` | `rez.cli.search` | Package search (exact / contains / regex) | ✅ Stable |
-| `rez_next.complete` | `rez.cli.complete` | Shell tab-completion script generation | ✅ Stable |
-| `rez_next.diff` | `rez.cli.diff` | Diff two resolved contexts | ✅ Stable |
-| `rez_next.status` | `rez.cli.status` | Query the currently active context | ✅ Stable |
-| `rez_next.depends` | `rez.cli.depends` | Reverse-dependency queries | ✅ Stable |
-| `rez_next.data` | `rez.data` | Built-in data resources | ✅ Stable |
-| `rez_next.cli` | `rez.cli` | CLI entry-points (programmatic invocation) | ✅ Stable |
-| `rez_next.exceptions` | `rez.exceptions` | Exception hierarchy | ✅ Stable |
-| `rez_next.utils.resources` | `rez.utils.resources` | Resource loading utilities | ✅ Stable |
+| `rez_next.solver` | `rez.solver` | Advanced solver API | ✅ Stable |
+| `rez_next.serialise_` | `rez.serialise` | Serialization support | ✅ Stable |
+| `rez_next.test` | `rez.test` | Package testing | ✅ Stable |
+| `rez_next.util` | `rez.utils` | Utility functions | ✅ Stable |
 
 ## Quick Start
 
@@ -185,21 +178,22 @@ print(result.format())
 
 ### Prerequisites
 
-- Rust 1.70+
+- Rust 1.95+ (MSRV in `Cargo.toml`)
 - Python 3.8+
 - Maturin (`pip install maturin`)
-- (Optional) `vx` for tool management
+- (Optional) `vx` for tool management (see `vx.toml`)
 
 ### Build Commands
 
 ```bash
 # Using just (recommended)
-just py-build
-just py-test
+vx just py-build
+vx just py-test
+vx just py-ci
 
 # Using maturin directly
 cd crates/rez-next-python
-vx maturin develop
+vx maturin develop --features pyo3/extension-module
 vx pytest tests/ -v --tb=short
 ```
 
@@ -298,7 +292,8 @@ maturin develop --release --python /path/to/python3.8
 ## Links
 
 - **Main documentation**: See [AGENTS.md](../AGENTS.md) for project map
-- **API reference**: See [llms-full.txt](../llms-full.txt) for complete API
+- **AI-friendly index**: See [llms.txt](../llms.txt) for concise API reference
+- **Complete API reference**: See [llms-full.txt](../llms-full.txt) for full API details
 - **Contributing**: See [contributing.md](./contributing.md)
 - **Benchmarks**: See [benchmark_guide.md](./benchmark_guide.md)
 - **Repository**: https://github.com/loonghao/rez-next

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,571 @@
+# rez-next — Complete API Reference
+
+> **Full API documentation for AI agents.** For a concise index, see [llms.txt](./llms.txt). For human guides, see [docs/](./docs/).
+
+---
+
+## Table of Contents
+
+1. [Project Structure](#project-structure)
+2. [Rust API](#rust-api)
+3. [Python API](#python-api)
+4. [CLI Reference](#cli-reference)
+5. [Development Commands](#development-commands)
+6. [Configuration Files](#configuration-files)
+
+---
+
+## Project Structure
+
+```
+rez-next/
+├── crates/                          # 20 Rust crates
+│   ├── rez-next-common/             # Shared: Error, Config, utilities
+│   ├── rez-next-config/             # Config loading & validation
+│   ├── rez-next-version/            # Version: parse, compare, range matching
+│   ├── rez-next-package/            # Package: Package, Variant, package.py parser
+│   ├── rez-next-package-cache/      # Package payload caching
+│   ├── rez-next-package-filter/     # Package filter: GlobRule, RangeRule, RegexRule
+│   ├── rez-next-solver/             # Solver: A* algorithm with backtracking
+│   ├── rez-next-repository/         # Repository: scan, index, cache packages
+│   ├── rez-next-context/            # Context: resolved contexts, Rex integration
+│   ├── rez-next-build/              # Build: rez-build system integration
+│   ├── rez-next-cache/              # Cache: multi-level (memory + disk)
+│   ├── rez-next-rex/                # Rex: Rex DSL interpreter
+│   ├── rez-next-suites/             # Suites: tool-chain management
+│   ├── rez-next-bind/               # Bind: system tool → rez package binding
+│   ├── rez-next-search/             # Search: fuzzy/exact/contains/regex search
+│   ├── rez-next-explicit/           # Explicit: explicit package lists
+│   ├── rez-next-serialise/          # Serialise: package serialization
+│   ├── rez-next-release-hook/       # Release hooks
+│   ├── rez-next-util/               # Util: command runner, helpers
+│   └── rez-next-python/             # Python: PyO3 bindings → _native.pyd
+├── src/                             # Rust CLI binary (rez-next)
+├── tests/                           # Integration tests (Rust + Python)
+├── benches/                         # Criterion benchmarks (11 benchmarks)
+├── examples/                        # Example code
+├── docs/                            # Human-oriented documentation
+├── python/                          # Python package layout
+└── metrics/                         # Performance tracking
+```
+
+---
+
+## Rust API
+
+### rez-next-version (`crates/rez-next-version/`)
+
+```rust
+use rez_next_version::{Version, VersionToken, VersionRange};
+
+// Parse a version
+let v = Version::parse("1.2.3").unwrap();
+
+// Compare versions
+assert!(v < Version::parse("2.0.0").unwrap());
+
+// Version ranges
+let range = VersionRange::parse(">=1.0,<2.0").unwrap();
+assert!(range.contains(&v));
+```
+
+### rez-next-package (`crates/rez-next-package/`)
+
+```rust
+use rez_next_package::{Package, Variant, PackageMaker};
+use rez_next_package::filter::{PackageFilter, GlobRule, RangeRule, RegexRule};
+
+// Create a package programmatically
+let pkg = PackageMaker::new("maya")
+    .version("2024.0")
+    .build().unwrap();
+
+// Filter packages
+let filter = PackageFilter::new()
+    .add_inclusion(GlobRule::new("maya-*").unwrap())
+    .add_exclusion(RangeRule::new("maya", "<2023").unwrap());
+```
+
+### rez-next-solver (`crates/rez-next-solver/`)
+
+```rust
+use rez_next_solver::{Solver, SolverConfig, SolverStatus};
+
+let config = SolverConfig::default();
+let solver = Solver::new(config);
+let request = &["python-3.9", "maya-2024"];
+match solver.solve(request) {
+    Ok(context) => println!("Resolved: {:?}", context.packages()),
+    Err(e) => eprintln!("Solve failed: {}", e),
+}
+```
+
+### rez-next-repository (`crates/rez-next-repository/`)
+
+```rust
+use rez_next_repository::{Repository, PackageRepository};
+
+// Scan a directory for packages
+let repo = PackageRepository::new("/path/to/packages");
+for pkg in repo.iter_packages() {
+    println!("{} {}", pkg.name(), pkg.version());
+}
+
+// Get latest version
+if let Some(pkg) = repo.get_latest("python") {
+    println!("Latest python: {}", pkg.version());
+}
+```
+
+### rez-next-context (`crates/rez-next-context/`)
+
+```rust
+use rez_next_context::{ResolvedContext, ContextConfig};
+
+let ctx = ResolvedContext::resolve(&["python-3.9"]);
+println!("Status: {:?}", ctx.status());
+for pkg in ctx.resolved_packages() {
+    println!("{}=={}", pkg.name(), pkg.version());
+}
+```
+
+### rez-next-rex (`crates/rez-next-rex/`)
+
+```rust
+use rez_next_rex::{RexInterpreter, RexEnvironment};
+
+let mut env = RexEnvironment::new();
+env.set("MY_VAR", "hello");
+env.prepend("PATH", "/custom/bin");
+env.alias("build", "cargo build --release");
+```
+
+### rez-next-build (`crates/rez-next-build/`)
+
+```rust
+use rez_next_build::{BuildSystem, BuildConfig, BuildResult};
+
+let config = BuildConfig::default();
+let result = BuildSystem::build("/path/to/package", &config)?;
+println!("Build complete: {:?}", result.files);
+```
+
+### rez-next-package-filter (`crates/rez-next-package-filter/`)
+
+```rust
+use rez_next_package_filter::{PackageFilter, PackageFilterList};
+use rez_next_package::filter::{GlobRule, RangeRule, RegexRule};
+
+// Glob-based filter
+let glob = GlobRule::new("python-3.*").unwrap();
+
+// Range-based filter
+let range = RangeRule::new("maya", ">=2023,<2026").unwrap();
+
+// Regex-based filter
+let regex = RegexRule::new(r"^maya.*", None).unwrap();
+
+// Combined filter list
+let mut filters = PackageFilterList::new();
+filters.add_inclusion(glob);
+filters.add_exclusion(range);
+```
+
+### rez-next-cache (`crates/rez-next-cache/`)
+
+```rust
+use rez_next_cache::{Cache, CacheConfig};
+
+let cache = Cache::new(CacheConfig::default());
+cache.put("key", b"data").unwrap();
+if let Some(data) = cache.get("key") {
+    println!("Hit: {} bytes", data.len());
+}
+```
+
+---
+
+## Python API
+
+### Version
+
+```python
+import rez_next as rez
+
+v = rez.PyVersion("1.2.3")
+v2 = rez.PyVersion("2.0.0")
+assert v < v2
+
+r = rez.PyVersionRange(">=3.9,<4.0")
+r.contains(rez.PyVersion("3.9.7"))  # True
+
+# Rez semantics: 1.0 > 1.0.0 (different interpretation)
+v_strict = rez.PyVersion("1.0")
+v_loose = rez.PyVersion("1.0.0")   # v_strict > v_loose
+```
+
+### Packages
+
+```python
+from rez_next.packages_ import iter_packages, get_latest_package
+
+pkg = get_latest_package("python")
+pkg.name      # "python"
+pkg.version   # PyVersion object
+
+for p in iter_packages("maya", range_=">=2023"):
+    print(p.name, p.version)
+```
+
+### Package Operations
+
+```python
+from rez_next.packages_ import (
+    get_latest_package,
+    iter_packages,
+    copy_package,
+    move_package,
+    remove_package,
+)
+```
+
+### Dependency Resolution
+
+```python
+from rez_next.resolved_context import ResolvedContext
+
+ctx = ResolvedContext.resolve_packages(["python-3.9", "maya-2024"])
+ctx.status              # "solved"
+ctx.resolved_packages   # list of resolved packages
+ctx.success             # bool
+
+# Get environment for context
+env = ctx.get_environ()
+for key, value in env.items():
+    print(f"{key}={value}")
+```
+
+### Config
+
+```python
+from rez_next.config import Config
+
+config = Config()
+config.packages_path       # package search paths
+config.local_packages_path # local packages
+config.release_packages_path
+config.debug               # bool
+```
+
+### System Info
+
+```python
+from rez_next.system import System
+
+s = System()
+s.platform     # "linux" | "darwin" | "windows"
+s.arch         # "x86_64" | "aarch64"
+s.os           # "linux" | "macosx" | "windows"
+s.python_version  # e.g., "3.11.0"
+```
+
+### Context Diff
+
+```python
+from rez_next.diff import diff_contexts, format_diff
+
+result = diff_contexts(
+    ["python-3.9", "maya-2023"],
+    ["python-3.11", "maya-2024"]
+)
+result.num_added       # int
+result.num_removed     # int
+result.num_changed     # int
+print(format_diff(result))
+```
+
+### Reverse Dependencies
+
+```python
+from rez_next.depends import get_reverse_dependencies
+
+result = get_reverse_dependencies("python", transitive=True)
+result.format()  # human-readable output
+```
+
+### Shell
+
+```python
+from rez_next.shell import Shell
+
+# Generate shell scripts for context activation
+shell = Shell("bash")     # or "zsh", "fish", "powershell", "cmd"
+script = shell.generate_activation_script(ctx)
+```
+
+### Rex
+
+```python
+from rez_next.rex import RexEnvironment
+
+env = RexEnvironment()
+env.set("MY_VAR", "value")
+env.prepend("PATH", "/custom/bin")
+env.alias("build", "cargo build --release")
+```
+
+### Build System
+
+```python
+from rez_next.build_ import build_package, BuildConfig
+
+config = BuildConfig()
+config.install_path = "/tmp/install"
+result = build_package("/path/to/package", config)
+```
+
+### Pip Conversion
+
+```python
+from rez_next.pip import pip_to_rez_package
+
+# Convert a pip package to rez format
+pip_to_rez_package("requests", version="2.28.0")
+```
+
+### Package Filter
+
+```python
+from rez_next.package_filter import PackageFilter, GlobRule, RangeRule
+
+f = PackageFilter()
+f.add_inclusion(GlobRule("python-3.*"))
+f.add_exclusion(RangeRule("maya", "<2023"))
+matched = f.matches(pkg)
+```
+
+### Package Test
+
+```python
+from rez_next.test import PackageTestRunner
+
+runner = PackageTestRunner()
+results = runner.run(pkg)
+results.summary()   # "3 passed, 1 failed, 0 skipped"
+```
+
+### Package Cache
+
+```python
+from rez_next.package_cache import PackageCache
+
+cache = PackageCache()
+cache.put(pkg)
+cached = cache.get("python", "3.9.7")
+```
+
+### Plugins
+
+```python
+from rez_next.plugins import PluginManager
+
+pm = PluginManager()
+pm.discover()        # discover available plugins
+pm.list_plugins()    # list all plugins
+pm.load("my_plugin") # load specific plugin
+```
+
+### Release
+
+```python
+from rez_next.release import release_package
+
+release_package(
+    "/path/to/package",
+    message="Release maya-2024.1",
+    variants=True,
+)
+```
+
+### Bind
+
+```python
+from rez_next.bind import bind_package
+
+# Bind a system tool as a rez package
+bind_package("ffmpeg", path="/usr/bin/ffmpeg")
+```
+
+### CLI
+
+```python
+from rez_next.cli import run
+
+# Programmatic CLI invocation
+run(["search", "maya", "--latest"])
+run(["context", "python-3.9", "maya-2024"])
+```
+
+### Exceptions
+
+```python
+from rez_next.exceptions import (
+    RezError,
+    PackageNotFoundError,
+    PackageFamilyNotFoundError,
+    ResolvedContextError,
+    BuildError,
+    ReleaseError,
+    RexError,
+    SolverError,
+    # ... and more
+)
+```
+
+### Serialization
+
+```python
+from rez_next.serialise_ import (
+    serialize_package,
+    deserialize_package,
+    serialize_context,
+    deserialize_context,
+)
+```
+
+---
+
+## CLI Reference
+
+```bash
+# Build and install
+rez-next --version
+rez-next --help
+
+# Package search
+rez-next search maya
+rez-next search python --latest
+rez-next search --regex "^maya-202[3-4]"
+
+# Context resolution
+rez-next context python-3.9 maya-2024
+rez-next context --output json python-3.9
+
+# Reverse dependencies
+rez-next depends python --transitive
+
+# Context diff
+rez-next diff python-3.9 python-3.11 maya-2024
+
+# Active context status
+rez-next status
+
+# Package info
+rez-next info maya-2024
+rez-next info python --all
+
+# Self-update
+rez-next self-update
+rez-next self-update --check
+rez-next self-update --version 0.3.2
+```
+
+---
+
+## Development Commands
+
+```bash
+# Via justfile (recommended)
+vx just build             # Debug build
+vx just build-release     # Release build
+vx just test              # All Rust tests
+vx just test-verbose      # Tests with output
+vx just lint              # Clippy (local: strict)
+vx just lint-ci           # Clippy (CI: correctness only)
+vx just fmt               # Format Rust code
+vx just fmt-check         # Check formatting
+vx just ci                # Full CI pipeline
+vx just bench             # Run benchmarks
+vx just doc               # Generate Rust docs
+vx just doc-check         # Check doc warnings
+
+# Python workflow
+vx just py-build          # maturin develop
+vx just py-test           # Run all Python tests
+vx just py-test-fast      # Fast (stop on first failure)
+vx just py-test-e2e       # E2E tests only
+vx just py-test-module MODULE  # Tests by module name
+vx just py-fmt            # Format Python (ruff)
+vx just py-lint           # Lint Python (ruff)
+vx just py-ci             # Full Python CI (build + test)
+
+# CLI E2E
+vx just cli-e2e           # Build + run CLI E2E tests
+vx just cli-e2e-release   # With release binary
+vx just cli-e2e-one TEST  # Single test
+
+# Pre-commit
+vx just pre-commit-install  # Install hooks
+vx just pre-commit          # Run on all files
+vx just pre-commit-update   # Update hook versions
+
+# Direct cargo commands
+vx cargo test --workspace
+vx cargo test --package rez-next-solver
+vx cargo bench --bench version_benchmark
+vx cargo clippy --workspace --all-targets
+```
+
+---
+
+## Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `Cargo.toml` | Rust workspace root, crates, dependencies |
+| `vx.toml` | Tool version management (Rust, maturin, etc.) |
+| `justfile` | Task runner (build, test, lint, CI) |
+| `rust-toolchain.toml` | Rust toolchain override |
+| `clippy.toml` | Clippy configuration |
+| `deny.toml` | Supply chain audit (cargo-deny) |
+| `renovate.json` | Automated dependency updates |
+| `release-please-config.json` | Automated release management |
+| `audit.toml` | Project audit configuration |
+| `.github/workflows/ci.yml` | GitHub Actions CI definition |
+
+---
+
+## Benchmark Results (Reference)
+
+| Operation | rez-next | Python Rez | Speedup |
+|-----------|----------|------------|---------|
+| Version parse | ~9.1 µs | ~250 µs | ~27× |
+| Version comparison | ~6.8 ns | ~120 ns | ~18× |
+| 100 versions sort | ~19 µs | ~500 µs | ~26× |
+| Package creation | ~35 ns | ~3 µs | ~86× |
+| YAML serialize | ~7.0 µs | ~200 µs | ~29× |
+| Package query | ~42 µs | ~5 ms | ~119× |
+| Context resolve | ~100 ms | ~2 s | ~20× |
+
+---
+
+## Key Design Decisions
+
+1. **Drop-in replacement**: `import rez_next as rez` works for most common workflows
+2. **abi3-py38**: Single wheel for Python 3.8+, no per-version builds
+3. **A* solver**: Guaranteed optimal solutions with configurable heuristics
+4. **Multi-level cache**: Memory (LRU) → Disk → Repository; transparent for consumers
+5. **State machine parsing**: Version parser uses a state machine for correctness
+6. **Conventional Commits**: Enforced by CI; drives release-please automation
+7. **SOLID principles**: Each crate has a single responsibility; traits for extensibility
+
+---
+
+## Links
+
+- **Repository**: https://github.com/loonghao/rez-next
+- **Issues**: https://github.com/loonghao/rez-next/issues
+- **Discussions**: https://github.com/loonghao/rez-next/discussions
+- **Upstream Rez**: https://github.com/AcademySoftwareFoundation/rez
+- **Crates.io**: https://crates.io/crates/rez-next
+- **PyPI**: https://pypi.org/project/rez-next/

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,130 @@
+# rez-next - LLM Usage Index
+
+> **AI-first compact reference.** For full API details, see [llms-full.txt](./llms-full.txt). For human guides, see [docs/](./docs/).
+
+## Project: rez-next v0.3.4
+
+High-performance Rust rewrite of [Rez](https://github.com/AcademySoftwareFoundation/rez) with Python bindings (PyO3). Import as `import rez_next as rez` for most workflows.
+
+- **Language**: Rust 2024 edition (MSRV 1.95) + Python 3.8+ (abi3)
+- **Build**: Cargo workspace (20 crates) + Maturin for Python
+- **Status**: Pre-1.0, experimental. Many Rez APIs work, not all.
+
+## Quick Commands
+
+```bash
+vx just build       # Build
+vx just test         # Run all tests
+vx just lint         # Clippy
+vx just ci           # Full CI (fmt + lint + test + doc)
+vx just bench        # Benchmarks
+vx just py-build     # Python wheel (maturin develop)
+vx just py-test      # Python tests
+```
+
+## Architecture Map (20 crates)
+
+```
+crates/
+├── rez-next-common/          # Error types, shared config, utilities
+├── rez-next-config/          # Configuration management
+├── rez-next-version/         # Version parsing (state machine), comparison, ranges
+├── rez-next-package/         # Package definition, package.py parser
+├── rez-next-package-cache/   # Package payload caching
+├── rez-next-package-filter/  # Package filter API (glob, regex, range rules)
+├── rez-next-solver/          # Dependency solver (A* + backtracking)
+├── rez-next-repository/      # Repository scanning, indexing, caching
+├── rez-next-context/         # Resolved contexts, serialization
+├── rez-next-build/           # Build system integration (rez-build compat)
+├── rez-next-cache/           # Multi-level caching (memory + disk)
+├── rez-next-rex/             # Rex DSL interpreter
+├── rez-next-suites/          # Suite management
+├── rez-next-bind/            # System tool binding
+├── rez-next-search/          # Package search
+├── rez-next-explicit/        # Explicit package lists
+├── rez-next-serialise/       # Serialization support
+├── rez-next-release-hook/    # Release hooks
+├── rez-next-util/            # Utility functions (command, etc.)
+└── rez-next-python/          # PyO3 Python bindings (_native.pyd)
+```
+
+## Python Submodules (37 files)
+
+| Module | Rez Equivalent | Key APIs |
+|--------|---------------|----------|
+| `rez_next.version` | `rez.vendor.version` | `PyVersion`, `PyVersionRange` |
+| `rez_next.packages_` | `rez.packages_` | `iter_packages`, `get_latest_package` |
+| `rez_next.packages` | `rez.packages` | Package object model |
+| `rez_next.resolved_context` | `rez.resolved_context` | `ResolvedContext`, `resolve_packages` |
+| `rez_next.solver_` | `rez.solver` | Solver configuration |
+| `rez_next.solver` | `rez.solver` | Advanced solver API |
+| `rez_next.config` | `rez.config` | `Config` singleton |
+| `rez_next.system` | `rez.system` | Platform info |
+| `rez_next.shell` | `rez.shells` | bash/zsh/fish/ps/cmd scripts |
+| `rez_next.rex` | `rez.rex` | Rex command language |
+| `rez_next.build_` | `rez.build_` | Build system |
+| `rez_next.build_plugins` | `rez.build_plugins` | Build plugins |
+| `rez_next.release` | `rez.release` | Package release |
+| `rez_next.bind` | `rez.bind` | System tool binding |
+| `rez_next.pip` | `rez.pip` | pip → rez conversion |
+| `rez_next.plugins` | `rez.plugins` | Plugin management |
+| `rez_next.env` | `rez.env` | Environment creation |
+| `rez_next.source` | `rez.source` | Context activation |
+| `rez_next.bundles` | `rez.bundles` | Context bundling |
+| `rez_next.forward` | `rez.forward` | Shell forward compat |
+| `rez_next.search` | `rez.cli.search` | Package search |
+| `rez_next.complete` | `rez.cli.complete` | Tab completion |
+| `rez_next.diff` | `rez.cli.diff` | Context diff |
+| `rez_next.status` | `rez.cli.status` | Active context query |
+| `rez_next.depends` | `rez.cli.depends` | Reverse dependencies |
+| `rez_next.data` | `rez.data` | Built-in resources |
+| `rez_next.cli` | `rez.cli` | CLI entry points |
+| `rez_next.exceptions` | `rez.exceptions` | Exception hierarchy |
+| `rez_next.deprecations` | `rez.utils.deprecations` | `RezDeprecationWarning` |
+| `rez_next.package_cache` | `rez.package_cache` | Package payload cache |
+| `rez_next.package_help` | `rez.package_help` | Package help |
+| `rez_next.package_search` | `rez.package_search` | Package search API |
+| `rez_next.package_remove` | `rez.package_remove` | Package removal |
+| `rez_next.serialise_` | `rez.serialise` | Serialization |
+| `rez_next.test` | `rez.test` | Package testing |
+| `rez_next.util` | `rez.utils` | Utility functions |
+| `rez_next.suite` | `rez.suite` | Suite management |
+
+## Common Agent Tasks
+
+### Add a new feature
+1. Implement in appropriate `crates/` module
+2. Expose via `crates/rez-next-python/` if Python-facing
+3. Add Rust `#[test]` + Python `pytest` tests
+4. Run `vx just ci` before PR
+5. Update docs (this file, llms-full.txt, docs/)
+
+### Debug solver issues
+→ `crates/rez-next-solver/` (A* with backtracking), `RUST_LOG=debug`
+
+### Profile performance
+→ `vx just bench`, see `docs/performance.md`
+
+### Check API coverage
+→ See `docs/python-integration.md`
+
+## Important Files
+
+| File | Purpose |
+|------|---------|
+| `AGENTS.md` | Progressive disclosure map (start here) |
+| `llms.txt` | This file - AI-friendly index |
+| `llms-full.txt` | Complete API reference |
+| `CLAUDE.md` | Claude-specific guidance |
+| `GEMINI.md` | Gemini-specific guidance |
+| `README.md` | User-facing overview |
+| `docs/` | Detailed human guides |
+| `vx.toml` | Tool version pinning |
+| `justfile` | Task runner recipes |
+
+## CI Pipeline
+
+- `.github/workflows/ci.yml` — main CI (build, test, lint, doc)
+- `release-please-config.json` — automated releases
+- `renovate.json` — dependency updates
+- `deny.toml` — supply chain audit


### PR DESCRIPTION
## Summary

Comprehensive documentation update to help AI agents and humans better understand and use the rez-next project.

## Changes

### New Files
- **\llms.txt\** — AI-friendly concise usage index: crate architecture map (20 crates), all 37 Python submodules, quick commands, common agent tasks
- **\llms-full.txt\** — Complete API reference: Rust API (all major crates), Python API (all submodules), CLI reference, development commands, benchmark results, design decisions

### Updated Files
- **\AGENTS.md\**: 
  - Updated version: 0.3.1 → 0.3.4
  - Fixed crate count: 13 → 20 (added missing crates: config, package-cache, package-filter, release-hook, serialise, explicit, util)
  - Fixed Python submodule count: 18 → 37
  - Added references to llms.txt and llms-full.txt
  - Updated MSRV: Rust 1.95, edition 2024
  - Updated Python testing commands to use justfile recipes
  - Removed reference to non-existent CLEANUP_TODO.md

- **\CLAUDE.md\** / **\GEMINI.md\**: 
  - Clarified progressive disclosure chain
  - Fixed llms.txt vs llms-full.txt purpose descriptions

- **\docs/python-integration.md\**: 
  - Removed 15 duplicate entries in the submodule table
  - Updated submodule table to reflect all 37 available modules
  - Updated MSRV from 1.70 to 1.95
  - Updated build commands to use justfile recipes
  - Added dual links: llms.txt (concise) + llms-full.txt (complete)

## Progressive Disclosure Design

\\\
AGENTS.md  →  project map (where to find things)
    ↓
llms.txt  →  concise AI index (crates, modules, quick commands)
    ↓
llms-full.txt  →  complete API reference (Rust + Python + CLI)
    ↓
docs/  →  detailed human guides
\\\

Closes: #N/A (documentation maintenance)