### PR TITLE
docs: comprehensive doc refresh - fix submodule counts and add missing modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,7 @@ result = diff_contexts(["python-3.9"], ["python-3.11", "maya-2024"])
 
 ⚠️ **Not all Rez features are implemented** — check coverage before suggesting code changes
 
-⚠️ **Python bindings are partial** — `rez-next-python` has 37 submodules, not full Rez coverage
+⚠️ **Python bindings are partial** — `rez-next-python` has 58 submodules, not full Rez coverage
 
 ⚠️ **Breaking changes possible** — pre-1.0 project, API may change
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # rez-next - AI Agent Guide
 
 > **Progressive disclosure map** — start here, then follow links to details.
+>
+> **Disclosure chain**: this file → [llms.txt](./llms.txt) (concise AI index) → [llms-full.txt](./llms-full.txt) (full API reference) → [docs/](./docs/) (human guides)
 
 ## Project Overview
 
@@ -9,8 +11,11 @@ rez-next is a **high-performance Rust rewrite** of the [Rez](https://github.com/
 **Key facts for agents:**
 - Language: Rust 2024 edition (MSRV 1.95) + Python 3.8+ bindings (PyO3 abi3)
 - Build system: Cargo workspace (20 crates) + Maturin for Python
-- Current version: 0.3.4
+- Current version: 0.3.4 (see [CHANGELOG.md](./CHANGELOG.md))
 - License: Apache 2.0
+- Python modules: **56+ submodules** (67 .py files) covering most Rez APIs
+- Native: **43 registered** PyO3 submodules, 25 native classes, ~50 top-level functions
+- Tests: **111 test files** (56 Python + 46 Rust + 9 fixtures)
 - Status: Many workflows work with `import rez_next as rez`, but **not yet a seamless drop-in** for every API surface
 
 ## Quick Start
@@ -184,7 +189,7 @@ result = diff_contexts(["python-3.9"], ["python-3.11", "maya-2024"])
 
 ⚠️ **Not all Rez features are implemented** — check coverage before suggesting code changes
 
-⚠️ **Python bindings are partial** — `rez-next-python` has 58 submodules, not full Rez coverage
+⚠️ **Python bindings are partial** — `rez_next` has 56+ submodules, covering most Rez APIs but not every edge case
 
 ⚠️ **Breaking changes possible** — pre-1.0 project, API may change
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,11 +43,11 @@ use rez_next_package::Package;
 ### 5. Documentation Updates
 
 When updating documentation:
-1. Update AGENTS.md if project structure changes
-2. Update llms.txt if AI-facing usage index changes
-3. Update llms-full.txt for detailed API changes
-4. Update docs/*.md for human-facing changes
-5. Update README.md for user-facing changes
+1. Update AGENTS.md (project map) if structure changes
+2. Update llms.txt (AI-friendly concise index) if submodule list changes
+3. Update llms-full.txt (complete API reference) for new APIs
+4. Update docs/*.md (human guides) for workflow changes
+5. Update README.md / README_zh.md for user-facing changes
 
 ### 6. Commit Messages
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -43,11 +43,11 @@ use rez_next_package::Package;
 ### 5. Documentation Updates
 
 When updating documentation:
-1. Update AGENTS.md if project structure changes
-2. Update llms.txt if AI-facing API changes
-3. Update llms-full.txt for detailed API changes
-4. Update docs/*.md for human-facing changes
-5. Update README.md for user-facing changes
+1. Update AGENTS.md (project map) if structure changes
+2. Update llms.txt (AI-friendly concise index) if submodule list changes
+3. Update llms-full.txt (complete API reference) for new APIs
+4. Update docs/*.md (human guides) for workflow changes
+5. Update README.md / README_zh.md for user-facing changes
 
 ### 6. Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,22 @@ for p in rez.iter_packages("maya"):
 | `rez_next.utils.filesystem` | `rez.utils.filesystem` | Filesystem utilities |
 | `rez_next.utils.formatting` | `rez.utils.formatting` | Output formatting |
 | `rez_next.utils.logging_` | `rez.utils.logging_` | Logging utilities |
+| `rez_next.utils.yaml` | `rez.utils.yaml` | YAML utilities |
+| `rez_next.utils.colorize` | `rez.utils.colorize` | Terminal color output |
+| `rez_next.utils.platform_` | `rez.utils.platform_` | Platform detection |
 | `rez_next.vendor.version` | `rez.vendor.version` | Vendored version module |
+| `rez_next.package_copy` | `rez.package_copy` | Package copy operations |
+| `rez_next.package_move` | `rez.package_move` | Package move operations |
+| `rez_next.package_order` | `rez.package_order` | Package sorting strategies |
+| `rez_next.package_bind` | `rez.package_bind` | Package bind utilities |
+| `rez_next.package_resources` | `rez.package_resources` | Package resource management |
+| `rez_next.package_serialise` | `rez.package_serialise` | Package serialization |
+| `rez_next.package_filter` | `rez.package_filter` | Filter rules (glob/range/regex) |
+| `rez_next.package_test` | `rez.package_test` | Package test runner |
+| `rez_next.developer_package` | `rez.developer_package` | Developer package workflow |
+| `rez_next.rex_bindings` | `rez.rex_bindings` | Rex low-level bindings |
+| `rez_next.shells` | `rez.shells` | Shell type registry |
+| `rez_next.rezconfig` | `rez.rezconfig` | Config defaults (100+ fields) |
 
 ### API Examples
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rez-next
 
-[![Rust](https://img.shields.io/badge/rust-1.70+-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.95+-orange.svg)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/loonghao/rez-next/ci.yml?branch=main)](https://github.com/loonghao/rez-next/actions)
 [![GitHub Release](https://img.shields.io/github/v/release/loonghao/rez-next)](https://github.com/loonghao/rez-next/releases)
@@ -113,20 +113,28 @@ for p in rez.iter_packages("maya"):
 |-----------|----------------------|---------------|
 | `rez_next.version` | `rez.vendor.version` | Version parsing, comparison, ranges |
 | `rez_next.packages_` | `rez.packages_` | Package iteration, queries, copy/move/remove |
+| `rez_next.packages` | `rez.packages` | Package object model |
 | `rez_next.resolved_context` | `rez.resolved_context` | Dependency resolution, context management |
 | `rez_next.suite` | `rez.suite` | Suite creation and tool-chain management |
-| `rez_next.config` | `rez.config` | Configuration reading |
+| `rez_next.config` | `rez.config` | Configuration reading (100+ fields) |
 | `rez_next.system` | `rez.system` | System info (platform, Python version, etc.) |
 | `rez_next.shell` | `rez.shells` | Shell script generation (bash/zsh/fish/PowerShell/cmd) |
 | `rez_next.rex` | `rez.rex` | Rex command-language interpreter |
 | `rez_next.build_` | `rez.build_` | Package build system integration |
+| `rez_next.build_process` | `rez.build_process` | Build process orchestration |
+| `rez_next.build_system` | `rez.build_system` | Build system abstraction |
+| `rez_next.build_plugins` | `rez.build_plugins` | Build plugins |
 | `rez_next.release` | `rez.release` | Package release workflow |
+| `rez_next.release_hook` | `rez.release_hook` | Release hooks |
+| `rez_next.release_vcs` | `rez.release_vcs` | VCS integration for releases |
 | `rez_next.bind` | `rez.bind` | Bind system tools as rez packages |
 | `rez_next.pip` | `rez.pip` | Convert pip packages to rez packages |
 | `rez_next.plugins` | `rez.plugins` | Plugin management |
+| `rez_next.plugin_managers` | `rez.plugin_managers` | Plugin manager implementations |
 | `rez_next.env` | `rez.env` | Environment creation and activation |
 | `rez_next.source` | `rez.source` | Context activation script generation |
 | `rez_next.bundles` | `rez.bundles` | Context bundling (offline use) |
+| `rez_next.bundle_context` | `rez.bundle_context` | Relocatable context bundles |
 | `rez_next.forward` | `rez.forward` | Shell forward-compatibility scripts |
 | `rez_next.search` | `rez.cli.search` | Package search (exact / contains / regex) |
 | `rez_next.complete` | `rez.cli.complete` | Shell tab-completion script generation |
@@ -136,7 +144,26 @@ for p in rez.iter_packages("maya"):
 | `rez_next.data` | `rez.data` | Built-in data resources (completion scripts, examples) |
 | `rez_next.cli` | `rez.cli` | CLI entry-points (programmatic invocation) |
 | `rez_next.exceptions` | `rez.exceptions` | Exception hierarchy |
+| `rez_next.deprecations` | `rez.utils.deprecations` | Deprecation warnings |
+| `rez_next.package_cache` | `rez.package_cache` | Package payload cache |
+| `rez_next.package_help` | `rez.package_help` | Package help |
+| `rez_next.package_maker` | `rez.package_maker` | Programmatic package creation |
+| `rez_next.package_repository` | `rez.package_repository` | Package repository abstraction |
+| `rez_next.package_search` | `rez.package_search` | Package search API |
+| `rez_next.package_remove` | `rez.package_remove` | Package removal |
+| `rez_next.solver_` | `rez.solver` | Dependency solver |
+| `rez_next.solver` | `rez.solver` | Advanced solver API |
+| `rez_next.serialise_` | `rez.serialise` | Serialization support |
+| `rez_next.test` | `rez.test` | Package testing |
+| `rez_next.util` | `rez.utils` | Utility functions |
+| `rez_next.command` | `rez.utils.command` | Command execution |
+| `rez_next.wrapper` | `rez.utils.wrapper` | Tool execution wrappers |
+| `rez_next.resolver` | `rez.resolver` | Package resolver |
 | `rez_next.utils.resources` | `rez.utils.resources` | Resource loading utilities |
+| `rez_next.utils.filesystem` | `rez.utils.filesystem` | Filesystem utilities |
+| `rez_next.utils.formatting` | `rez.utils.formatting` | Output formatting |
+| `rez_next.utils.logging_` | `rez.utils.logging_` | Logging utilities |
+| `rez_next.vendor.version` | `rez.vendor.version` | Vendored version module |
 
 ### API Examples
 
@@ -252,22 +279,29 @@ print(script)
 
 ## Architecture
 
-A Cargo workspace with 13 crates, including `rez-next-python` for Python bindings:
+A Cargo workspace with 20 crates, including `rez-next-python` for Python bindings:
 
 ```
-rez-next-common       Shared error types, config, utilities
-rez-next-version      Version parsing, comparison, ranges (state-machine parser)
-rez-next-package      Package definition, package.py parsing (RustPython AST)
-rez-next-solver       Dependency resolution (A* algorithm + backtracking + cycle detection)
-rez-next-repository   Repository scanning and caching
-rez-next-context      Resolved context, Rex integration, serialization
-rez-next-build        Build system integration (cmake/make/python/cargo/nodejs)
-rez-next-cache        Multi-level caching (memory + disk)
-rez-next-rex          Rex command language (full DSL + 5 shell activation scripts)
-rez-next-suites       Suite management (collections of resolved contexts)
-rez-next-bind         Bind system tools (python/cmake/pip/git, etc.)
-rez-next-search       Package search (exact / contains / regex FilterMode)
-rez-next-python       Python bindings via PyO3 (18 submodules)
+rez-next-common        Shared error types, config, utilities
+rez-next-config        Config loading & validation
+rez-next-version       Version parsing, comparison, ranges (state-machine parser)
+rez-next-package       Package definition, package.py parsing (RustPython AST)
+rez-next-package-cache Package payload caching
+rez-next-package-filter Package filter (glob, regex, range rules)
+rez-next-solver        Dependency resolution (A* algorithm + backtracking + cycle detection)
+rez-next-repository    Repository scanning and caching
+rez-next-context       Resolved context, Rex integration, serialization
+rez-next-build         Build system integration (cmake/make/python/cargo/nodejs)
+rez-next-cache         Multi-level caching (memory + disk)
+rez-next-rex           Rex command language (full DSL + 5 shell activation scripts)
+rez-next-suites        Suite management (collections of resolved contexts)
+rez-next-bind          Bind system tools (python/cmake/pip/git, etc.)
+rez-next-search        Package search (exact / contains / regex FilterMode)
+rez-next-explicit      Explicit package lists
+rez-next-serialise     Package serialization
+rez-next-release-hook  Release hooks
+rez-next-util          Utility functions (command runner, etc.)
+rez-next-python        Python bindings via PyO3 (58 submodules)
 ```
 
 ### Component status
@@ -277,6 +311,7 @@ rez-next-python       Python bindings via PyO3 (18 submodules)
 | `rez-next-version` | Mature core | ~30 |
 | `rez-next-package` | Mature core | ~25 |
 | `rez-next-common` | Mature core | ~10 |
+| `rez-next-config` | Stable | ~8 |
 | `rez-next-rex` | Mature core | ~20 |
 | `rez-next-solver` | Active development (A* enabled) | ~15 |
 | `rez-next-context` | Active development | ~12 |
@@ -286,7 +321,13 @@ rez-next-python       Python bindings via PyO3 (18 submodules)
 | `rez-next-suites` | Active development | ~10 |
 | `rez-next-bind` | Active development | ~37 |
 | `rez-next-search` | Active development | ~16 |
-| `rez-next-python` | Partial compatibility (18 submodules) | ~125 |
+| `rez-next-package-cache` | Stable | ~8 |
+| `rez-next-package-filter` | Stable | ~12 |
+| `rez-next-release-hook` | Stable | ~6 |
+| `rez-next-serialise` | Stable | ~5 |
+| `rez-next-explicit` | Stable | ~5 |
+| `rez-next-util` | Stable | ~5 |
+| `rez-next-python` | Partial compatibility (58 submodules) | ~125 |
 | Compat integration tests | Growing coverage | ~210 |
 
 ---
@@ -301,19 +342,19 @@ cargo build --release
 
 ### Prerequisites
 
-- Rust 1.70+
+- Rust 1.95+
 - [just](https://github.com/casey/just) (optional, convenience commands)
 
 ### Common commands
 
 ```bash
-just build           # Dev build
-just build-release   # Release build
-just test            # Run all tests
-just lint            # Clippy
-just fmt             # Format
-just ci              # Full CI check
-just bench           # Benchmarks
+vx just build           # Dev build
+vx just build-release   # Release build
+vx just test            # Run all tests
+vx just lint            # Clippy
+vx just fmt             # Format
+vx just ci              # Full CI check
+vx just bench           # Benchmarks
 ```
 
 ---
@@ -397,10 +438,17 @@ Measured with `pytest-benchmark` (Python layer over Rust core).
 ## Documentation
 
 - [Contributing](docs/contributing.md) — development workflow and CI
+- [Python Integration](docs/python-integration.md) — Python bindings usage and module coverage
 - [Benchmark Guide](docs/benchmark_guide.md) — running and interpreting benchmarks
 - [Performance Guide](docs/performance.md) — profiling tools
-- [Python Integration](docs/python-integration.md) — Python bindings usage
 - [Pre-commit Setup](docs/PRE_COMMIT_SETUP.md) — code quality hooks
+
+### For AI Agents
+- [AGENTS.md](AGENTS.md) — progressive disclosure map (start here)
+- [llms.txt](llms.txt) — AI-friendly concise usage index
+- [llms-full.txt](llms-full.txt) — complete API reference
+- [CLAUDE.md](CLAUDE.md) — Claude-specific guidance
+- [GEMINI.md](GEMINI.md) — Gemini-specific guidance
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -163,7 +163,22 @@ for p in rez.iter_packages("maya"):
 | `rez_next.utils.filesystem` | `rez.utils.filesystem` | 文件系统工具 |
 | `rez_next.utils.formatting` | `rez.utils.formatting` | 输出格式化 |
 | `rez_next.utils.logging_` | `rez.utils.logging_` | 日志工具 |
+| `rez_next.utils.yaml` | `rez.utils.yaml` | YAML 工具 |
+| `rez_next.utils.colorize` | `rez.utils.colorize` | 终端颜色输出 |
+| `rez_next.utils.platform_` | `rez.utils.platform_` | 平台检测 |
 | `rez_next.vendor.version` | `rez.vendor.version` | 内置版本模块 |
+| `rez_next.package_copy` | `rez.package_copy` | 包复制操作 |
+| `rez_next.package_move` | `rez.package_move` | 包移动操作 |
+| `rez_next.package_order` | `rez.package_order` | 包排序策略 |
+| `rez_next.package_bind` | `rez.package_bind` | 包绑定工具 |
+| `rez_next.package_resources` | `rez.package_resources` | 包资源管理 |
+| `rez_next.package_serialise` | `rez.package_serialise` | 包序列化 |
+| `rez_next.package_filter` | `rez.package_filter` | 过滤规则 (glob/range/regex) |
+| `rez_next.package_test` | `rez.package_test` | 包测试运行器 |
+| `rez_next.developer_package` | `rez.developer_package` | 开发者包工作流 |
+| `rez_next.rex_bindings` | `rez.rex_bindings` | Rex 底层绑定 |
+| `rez_next.shells` | `rez.shells` | Shell 类型注册 |
+| `rez_next.rezconfig` | `rez.rezconfig` | 配置默认值 (100+ 字段) |
 
 ### API 示例
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,6 +1,6 @@
 # rez-next
 
-[![Rust](https://img.shields.io/badge/rust-1.70+-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.95+-orange.svg)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/loonghao/rez-next/ci.yml?branch=main)](https://github.com/loonghao/rez-next/actions)
 [![GitHub Release](https://img.shields.io/github/v/release/loonghao/rez-next)](https://github.com/loonghao/rez-next/releases)
@@ -113,30 +113,57 @@ for p in rez.iter_packages("maya"):
 |--------|--------------|------|
 | `rez_next.version` | `rez.vendor.version` | 版本解析、比较、范围 |
 | `rez_next.packages_` | `rez.packages_` | 包迭代、查询、复制/移动/删除 |
+| `rez_next.packages` | `rez.packages` | 包对象模型 |
 | `rez_next.resolved_context` | `rez.resolved_context` | 依赖解析、上下文管理 |
 | `rez_next.suite` | `rez.suite` | Suite 创建、工具链管理 |
-| `rez_next.config` | `rez.config` | 配置读取 |
+| `rez_next.config` | `rez.config` | 配置读取（100+ 字段）|
 | `rez_next.system` | `rez.system` | 系统信息（平台、Python版本等） |
 | `rez_next.shell` | `rez.shells` | Shell 脚本生成（bash/zsh/fish/PowerShell/cmd）|
 | `rez_next.rex` | `rez.rex` | Rex 命令语言解释器 |
 | `rez_next.build_` | `rez.build_` | 包构建系统集成 |
+| `rez_next.build_process` | `rez.build_process` | 构建流程编排 |
+| `rez_next.build_system` | `rez.build_system` | 构建系统抽象 |
+| `rez_next.build_plugins` | `rez.build_plugins` | 构建插件 |
 | `rez_next.release` | `rez.release` | 包发布流程 |
+| `rez_next.release_hook` | `rez.release_hook` | 发布钩子 |
+| `rez_next.release_vcs` | `rez.release_vcs` | VCS 发布集成 |
 | `rez_next.bind` | `rez.bind` | 系统工具绑定为 rez 包 |
 | `rez_next.pip` | `rez.pip` | pip 包转换为 rez 包 |
 | `rez_next.plugins` | `rez.plugins` | 插件管理 |
+| `rez_next.plugin_managers` | `rez.plugin_managers` | 插件管理器实现 |
 | `rez_next.env` | `rez.env` | 环境创建与激活 |
 | `rez_next.source` | `rez.source` | 上下文激活脚本生成 |
 | `rez_next.bundles` | `rez.bundles` | 上下文打包（离线使用）|
+| `rez_next.bundle_context` | `rez.bundle_context` | 可重定位上下文打包 |
 | `rez_next.forward` | `rez.forward` | Shell 前向兼容脚本 |
 | `rez_next.search` | `rez.cli.search` | 包搜索（精确/包含/正则）|
 | `rez_next.complete` | `rez.cli.complete` | Shell tab 补全脚本生成 |
 | `rez_next.diff` | `rez.cli.diff` | 两个已解析上下文的差异比对 |
 | `rez_next.status` | `rez.cli.status` | 当前激活上下文状态查询 |
 | `rez_next.depends` | `rez.cli.depends` | 反向依赖查询 |
-| `rez_next.data` | `rez.data` | 内置数据资源（补全脚本、示例）|
+| `rez_next.data` | `rez.data` | 内置数据资源 |
 | `rez_next.cli` | `rez.cli` | CLI 入口（程序化调用）|
 | `rez_next.exceptions` | `rez.exceptions` | 异常类 |
+| `rez_next.deprecations` | `rez.utils.deprecations` | 弃用警告 |
+| `rez_next.package_cache` | `rez.package_cache` | 包负载缓存 |
+| `rez_next.package_help` | `rez.package_help` | 包帮助 |
+| `rez_next.package_maker` | `rez.package_maker` | 编程式包创建 |
+| `rez_next.package_repository` | `rez.package_repository` | 包仓库抽象 |
+| `rez_next.package_search` | `rez.package_search` | 包搜索 API |
+| `rez_next.package_remove` | `rez.package_remove` | 包删除 |
+| `rez_next.solver_` | `rez.solver` | 依赖求解器 |
+| `rez_next.solver` | `rez.solver` | 高级求解器 API |
+| `rez_next.serialise_` | `rez.serialise` | 序列化支持 |
+| `rez_next.test` | `rez.test` | 包测试 |
+| `rez_next.util` | `rez.utils` | 工具函数 |
+| `rez_next.command` | `rez.utils.command` | 命令执行 |
+| `rez_next.wrapper` | `rez.utils.wrapper` | 工具执行包装器 |
+| `rez_next.resolver` | `rez.resolver` | 包解析器 |
 | `rez_next.utils.resources` | `rez.utils.resources` | 资源加载工具 |
+| `rez_next.utils.filesystem` | `rez.utils.filesystem` | 文件系统工具 |
+| `rez_next.utils.formatting` | `rez.utils.formatting` | 输出格式化 |
+| `rez_next.utils.logging_` | `rez.utils.logging_` | 日志工具 |
+| `rez_next.vendor.version` | `rez.vendor.version` | 内置版本模块 |
 
 ### API 示例
 
@@ -252,22 +279,29 @@ print(script)
 
 ## 架构
 
-Cargo workspace 包含 13 个 crate，其中 `rez-next-python` 提供 Python bindings：
+Cargo workspace 包含 20 个 crate，其中 `rez-next-python` 提供 Python bindings：
 
 ```
-rez-next-common       共享错误类型、配置、工具函数
-rez-next-version      版本解析、比较、范围（状态机解析器）
-rez-next-package      包定义、package.py 解析（RustPython AST）
-rez-next-solver       依赖求解（A* 算法 + 回溯 + 环检测）
-rez-next-repository   仓库扫描和缓存
-rez-next-context      已解析上下文、Rex 集成、序列化
-rez-next-build        构建系统集成（cmake/make/python/cargo/nodejs）
-rez-next-cache        多级缓存（内存 + 磁盘）
-rez-next-rex          Rex 命令语言（完整 DSL + 5 种 shell 激活脚本）
-rez-next-suites       Suite 管理（已解析上下文集合）
-rez-next-bind         系统工具绑定（python/cmake/pip/git 等）
-rez-next-search       包搜索（精确/包含/正则 FilterMode）
-rez-next-python       Python 绑定 via PyO3（18 个子模块）
+rez-next-common        共享错误类型、配置、工具函数
+rez-next-config        配置加载与校验
+rez-next-version       版本解析、比较、范围（状态机解析器）
+rez-next-package       包定义、package.py 解析（RustPython AST）
+rez-next-package-cache 包负载缓存
+rez-next-package-filter 包过滤（glob, regex, range rules）
+rez-next-solver        依赖求解（A* 算法 + 回溯 + 环检测）
+rez-next-repository    仓库扫描和缓存
+rez-next-context       已解析上下文、Rex 集成、序列化
+rez-next-build         构建系统集成（cmake/make/python/cargo/nodejs）
+rez-next-cache         多级缓存（内存 + 磁盘）
+rez-next-rex           Rex 命令语言（完整 DSL + 5 种 shell 激活脚本）
+rez-next-suites        Suite 管理（已解析上下文集合）
+rez-next-bind          系统工具绑定（python/cmake/pip/git 等）
+rez-next-search        包搜索（精确/包含/正则 FilterMode）
+rez-next-explicit      显式包列表
+rez-next-serialise     包序列化
+rez-next-release-hook  发布钩子
+rez-next-util          工具函数（命令执行等）
+rez-next-python        Python 绑定 via PyO3（58 个子模块）
 ```
 
 ### 各组件状态
@@ -277,6 +311,7 @@ rez-next-python       Python 绑定 via PyO3（18 个子模块）
 | `rez-next-version` | 核心能力较成熟 | ~30 |
 | `rez-next-package` | 核心能力较成熟 | ~25 |
 | `rez-next-common` | 核心能力较成熟 | ~10 |
+| `rez-next-config` | 稳定 | ~8 |
 | `rez-next-rex` | 核心能力较成熟 | ~20 |
 | `rez-next-solver` | 持续演进中（A* 已启用）| ~15 |
 | `rez-next-context` | 持续演进中 | ~12 |
@@ -286,7 +321,13 @@ rez-next-python       Python 绑定 via PyO3（18 个子模块）
 | `rez-next-suites` | 持续演进中 | ~10 |
 | `rez-next-bind` | 持续演进中 | ~37 |
 | `rez-next-search` | 持续演进中 | ~16 |
-| `rez-next-python` | 部分兼容（18 个子模块） | ~101 |
+| `rez-next-package-cache` | 稳定 | ~8 |
+| `rez-next-package-filter` | 稳定 | ~12 |
+| `rez-next-release-hook` | 稳定 | ~6 |
+| `rez-next-serialise` | 稳定 | ~5 |
+| `rez-next-explicit` | 稳定 | ~5 |
+| `rez-next-util` | 稳定 | ~5 |
+| `rez-next-python` | 部分兼容（58 个子模块） | ~125 |
 | Compat integration | 覆盖面持续增长 | ~210 |
 
 ---
@@ -301,19 +342,19 @@ cargo build --release
 
 ### 前置条件
 
-- Rust 1.70+
+- Rust 1.95+
 - [just](https://github.com/casey/just)（可选，便捷命令）
 
 ### 常用命令
 
 ```bash
-just build           # 开发构建
-just build-release   # 发布构建
-just test            # 运行所有测试
-just lint            # Clippy
-just fmt             # 格式化
-just ci              # 完整 CI 检查
-just bench           # 基准测试
+vx just build           # 开发构建
+vx just build-release   # 发布构建
+vx just test            # 运行所有测试
+vx just lint            # Clippy
+vx just fmt             # 格式化
+vx just ci              # 完整 CI 检查
+vx just bench           # 基准测试
 ```
 
 ---
@@ -396,10 +437,17 @@ cargo bench --bench simple_package_benchmark
 ## 文档
 
 - [贡献指南](docs/contributing.md) — 开发工作流和 CI
+- [Python 集成](docs/python-integration_zh.md) — Python 绑定使用说明与模块覆盖
 - [基准测试指南](docs/benchmark_guide.md) — 运行和解读基准测试
 - [性能指南](docs/performance.md) — 性能分析工具
-- [Python 集成](docs/python-integration_zh.md) — Python 绑定使用说明
 - [Pre-commit 配置](docs/PRE_COMMIT_SETUP.md) — 代码质量钩子
+
+### 面向 AI Agent
+- [AGENTS.md](AGENTS.md) — 渐进式信息披露地图（从这里开始）
+- [llms.txt](llms.txt) — AI 友好的精简用法索引
+- [llms-full.txt](llms-full.txt) — 完整 API 参考
+- [CLAUDE.md](CLAUDE.md) — Claude 专用指南
+- [GEMINI.md](GEMINI.md) — Gemini 专用指南
 
 ---
 

--- a/docs/python-integration.md
+++ b/docs/python-integration.md
@@ -63,15 +63,18 @@ rez_next/
 ├── resolver.py             # rez_next.resolver
 ├── utils/                  # rez_next.utils subpackage
 │   ├── __init__.py
+│   ├── colorize.py
+│   ├── data_utils.py
 │   ├── filesystem.py
 │   ├── formatting.py
 │   ├── logging_.py
+│   ├── platform_.py
 │   ├── resources.py
 │   └── yaml.py
 ├── vendor/                 # rez_next.vendor subpackage
 │   ├── __init__.py
 │   └── version.py
-└── ...                     # (58 submodules total)
+└── ...                     # (67 .py files, 56+ submodules)
 ```
 
 ## Implemented Python Submodules
@@ -131,7 +134,23 @@ rez_next/
 | `rez_next.utils.formatting` | `rez.utils.formatting` | Output formatting | ✅ Stable |
 | `rez_next.utils.logging_` | `rez.utils.logging_` | Logging utilities | ✅ Stable |
 | `rez_next.utils.yaml` | `rez.utils.yaml` | YAML utilities | ✅ Stable |
+| `rez_next.utils.resources` | `rez.utils.resources` | Resource loading utilities | ✅ Stable |
+| `rez_next.utils.colorize` | `rez.utils.colorize` | Terminal color output | ✅ Stable |
+| `rez_next.utils.data_utils` | `rez.utils.data_utils` | Data file helpers | ✅ Stable |
+| `rez_next.utils.platform_` | `rez.utils.platform_` | Platform detection utilities | ✅ Stable |
 | `rez_next.vendor.version` | `rez.vendor.version` | Vendored version module | ✅ Stable |
+| `rez_next.package_copy` | `rez.package_copy` | Package copy operations | ✅ Stable |
+| `rez_next.package_move` | `rez.package_move` | Package move operations | ✅ Stable |
+| `rez_next.package_order` | `rez.package_order` | Package ordering strategies | ✅ Stable |
+| `rez_next.package_bind` | `rez.package_bind` | Package bind utilities | ✅ Stable |
+| `rez_next.package_resources` | `rez.package_resources` | Package resource management | ✅ Stable |
+| `rez_next.package_serialise` | `rez.package_serialise` | Package serialization | ✅ Stable |
+| `rez_next.package_filter` | `rez.package_filter` | Package filter rules | ✅ Stable |
+| `rez_next.package_test` | `rez.package_test` | Package test runner | ✅ Stable |
+| `rez_next.developer_package` | `rez.developer_package` | Developer package support | ✅ Stable |
+| `rez_next.rex_bindings` | `rez.rex_bindings` | Rex low-level bindings | ✅ Stable |
+| `rez_next.shells` | `rez.shells` | Shell type registry | ✅ Stable |
+| `rez_next.rezconfig` | `rez.rezconfig` | Config defaults module | ✅ Stable |
 
 ## Quick Start
 

--- a/docs/python-integration.md
+++ b/docs/python-integration.md
@@ -10,26 +10,68 @@ Python bindings are **partially implemented** in `crates/rez-next-python` and ex
 
 ```
 rez_next/
-├── _native.*.pyd        # PyO3 native extension (abi3-py38)
-├── __init__.py           # Exports, version, drop-in shims
-├── version.py            # rez_next.version
-├── packages_.py          # rez_next.packages_
-├── resolved_context.py    # rez_next.resolved_context
-├── solver_.py            # rez_next.solver (partial)
-├── suite.py              # rez_next.suite
-├── config.py             # rez_next.config
-├── system.py             # rez_next.system
-├── shell.py              # rez_next.shell
-├── rex.py                # rez_next.rex
-├── build_.py             # rez_next.build_ (partial)
-├── release.py            # rez_next.release (partial)
-├── bind.py               # rez_next.bind
-├── search.py             # rez_next.search
-├── diff.py               # rez_next.diff
-├── depends.py            # rez_next.depends
-├── status.py             # rez_next.status
-├── complete.py           # rez_next.complete
-└── ...                   # (18 submodules total)
+├── _native.*.pyd          # PyO3 native extension (abi3-py38)
+├── __init__.py             # Exports, version, drop-in shims
+├── version.py              # rez_next.version
+├── packages_.py            # rez_next.packages_
+├── packages.py             # rez_next.packages
+├── resolved_context.py      # rez_next.resolved_context
+├── solver_.py              # rez_next.solver
+├── solver.py               # rez_next.solver (advanced)
+├── suite.py                # rez_next.suite
+├── config.py               # rez_next.config (100+ fields)
+├── system.py               # rez_next.system
+├── shell.py                # rez_next.shell
+├── rex.py                  # rez_next.rex
+├── build_.py               # rez_next.build_
+├── build_process.py        # rez_next.build_process
+├── build_system.py         # rez_next.build_system
+├── build_plugins.py        # rez_next.build_plugins
+├── release.py              # rez_next.release
+├── release_hook.py         # rez_next.release_hook
+├── release_vcs.py          # rez_next.release_vcs
+├── bind.py                 # rez_next.bind
+├── pip.py                  # rez_next.pip
+├── plugins.py              # rez_next.plugins
+├── plugin_managers.py      # rez_next.plugin_managers
+├── env.py                  # rez_next.env
+├── source.py               # rez_next.source
+├── bundles.py              # rez_next.bundles
+├── bundle_context.py       # rez_next.bundle_context
+├── forward.py              # rez_next.forward
+├── search.py               # rez_next.search
+├── complete.py             # rez_next.complete
+├── diff.py                 # rez_next.diff
+├── depends.py              # rez_next.depends
+├── status.py               # rez_next.status
+├── data.py                 # rez_next.data
+├── cli.py                  # rez_next.cli
+├── exceptions.py           # rez_next.exceptions
+├── deprecations.py         # rez_next.deprecations
+├── package_cache.py        # rez_next.package_cache
+├── package_help.py         # rez_next.package_help
+├── package_maker.py        # rez_next.package_maker
+├── package_repository.py   # rez_next.package_repository
+├── package_search.py       # rez_next.package_search
+├── package_remove.py       # rez_next.package_remove
+├── package_py_utils.py     # rez_next.package_py_utils
+├── serialise_.py           # rez_next.serialise_
+├── test.py                 # rez_next.test
+├── util.py                 # rez_next.util
+├── command.py              # rez_next.command
+├── wrapper.py              # rez_next.wrapper
+├── resolver.py             # rez_next.resolver
+├── utils/                  # rez_next.utils subpackage
+│   ├── __init__.py
+│   ├── filesystem.py
+│   ├── formatting.py
+│   ├── logging_.py
+│   ├── resources.py
+│   └── yaml.py
+├── vendor/                 # rez_next.vendor subpackage
+│   ├── __init__.py
+│   └── version.py
+└── ...                     # (58 submodules total)
 ```
 
 ## Implemented Python Submodules
@@ -73,6 +115,23 @@ rez_next/
 | `rez_next.serialise_` | `rez.serialise` | Serialization support | ✅ Stable |
 | `rez_next.test` | `rez.test` | Package testing | ✅ Stable |
 | `rez_next.util` | `rez.utils` | Utility functions | ✅ Stable |
+| `rez_next.package_maker` | `rez.package_maker` | Programmatic package creation | ✅ Stable |
+| `rez_next.package_repository` | `rez.package_repository` | Package repository abstraction | ✅ Stable |
+| `rez_next.package_py_utils` | `rez.package_py_utils` | package.py utilities | ✅ Stable |
+| `rez_next.build_process` | `rez.build_process` | Build process orchestration | ✅ Stable |
+| `rez_next.build_system` | `rez.build_system` | Build system abstraction | ✅ Stable |
+| `rez_next.release_hook` | `rez.release_hook` | Release hooks | ✅ Stable |
+| `rez_next.release_vcs` | `rez.release_vcs` | VCS release integration | ✅ Stable |
+| `rez_next.wrapper` | `rez.utils.wrapper` | Tool execution wrappers | ✅ Stable |
+| `rez_next.bundle_context` | `rez.bundle_context` | Relocatable context bundles | ✅ Stable |
+| `rez_next.command` | `rez.utils.command` | Command execution | ✅ Stable |
+| `rez_next.resolver` | `rez.resolver` | Package resolver | ✅ Stable |
+| `rez_next.plugin_managers` | `rez.plugin_managers` | Plugin manager implementations | ✅ Stable |
+| `rez_next.utils.filesystem` | `rez.utils.filesystem` | Filesystem utilities | ✅ Stable |
+| `rez_next.utils.formatting` | `rez.utils.formatting` | Output formatting | ✅ Stable |
+| `rez_next.utils.logging_` | `rez.utils.logging_` | Logging utilities | ✅ Stable |
+| `rez_next.utils.yaml` | `rez.utils.yaml` | YAML utilities | ✅ Stable |
+| `rez_next.vendor.version` | `rez.vendor.version` | Vendored version module | ✅ Stable |
 
 ## Quick Start
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -524,6 +524,116 @@ logger = get_logger(__name__)
 logger.info("Processing package...")
 ```
 
+### Package Copy / Move / Order
+
+```python
+from rez_next.package_copy import copy_package
+from rez_next.package_move import move_package
+from rez_next.package_order import (
+    NullPackageOrder, SortedOrder, VersionSplitOrder,
+    TimestampPackageOrder, PackageOrderList, sort_packages,
+)
+
+# Copy a package
+copy_package(pkg, "/new/path")
+
+# Move a package
+move_package(pkg, "/new/path")
+
+# Sort packages by different strategies
+order = SortedOrder(descending=True)
+sorted_list = sort_packages(packages, order)
+```
+
+### Package Resources / Serialise
+
+```python
+from rez_next.package_resources import (
+    find_package_resource, list_package_resources, open_package_resource,
+)
+from rez_next.package_serialise import (
+    serialise_package, deserialise_package,
+    PackageSerialisationFormat,
+)
+
+# Access package-embedded resources
+path = find_package_resource(pkg, "icons/icon.png")
+contents = open_package_resource(pkg, "README.md").read()
+
+# Serialize packages to/from formats
+json_str = serialise_package(pkg, format=PackageSerialisationFormat.JSON)
+pkg2 = deserialise_package(json_str, format=PackageSerialisationFormat.JSON)
+```
+
+### Package Filter
+
+```python
+from rez_next.package_filter import (
+    PackageFilter, PackageFilterList,
+    GlobRule, RangeRule, RegexRule,
+)
+
+# Glob-based filter
+glob = GlobRule("python-3.*")
+glob.matches(pkg)
+
+# Range-based filter
+range_rule = RangeRule("maya", ">=2023,<2026")
+
+# Regex-based filter
+regex = RegexRule(r"^maya-202[3-4]", field="name")
+
+# Combined filter list
+filters = PackageFilterList()
+filters.add_inclusion(glob)
+filters.add_exclusion(range_rule)
+print(f"Total cost: {filters.cost()}")
+```
+
+### Package Bind / Developer Package
+
+```python
+from rez_next.package_bind import bind_package, unbind_package
+from rez_next.developer_package import DeveloperPackage
+
+# Bind a system tool as a rez package
+bind_package("ffmpeg", path="/usr/bin/ffmpeg")
+
+# Developer package mode (local dev)
+dev_pkg = DeveloperPackage("/path/to/my_package")
+dev_pkg.install()
+```
+
+### Shells / Rex Bindings
+
+```python
+from rez_next.shells import Shell, get_shell_types
+from rez_next.rex_bindings import RexBindings
+
+# List available shell types
+for shell_name in get_shell_types():
+    print(shell_name)  # bash, zsh, fish, powershell, cmd
+
+# Generate shell script
+shell = Shell("powershell")
+script = shell.generate_activation_script(ctx)
+```
+
+### Resolver
+
+```python
+from rez_next.resolver import resolve_package, Resolver
+
+# Simple resolution
+ctx = resolve_package("python-3.9")
+
+# Advanced resolution
+resolver = Resolver()
+resolver.add_request("python-3.9")
+resolver.add_request("maya-2024")
+ctx = resolver.solve()
+```
+
 ### Vendor (Version)
 
 ```python
@@ -531,6 +641,24 @@ from rez_next.vendor.version import Version
 
 v = Version("1.2.3")
 print(v.major, v.minor, v.patch)
+```
+
+### Utils Extended (colorize / data_utils / platform_)
+
+```python
+from rez_next.utils.colorize import colorize, Colors
+from rez_next.utils.data_utils import read_data_file
+from rez_next.utils.platform_ import Platform
+
+# Terminal color output
+print(colorize("Success!", Colors.GREEN))
+
+# Read built-in data files
+content = read_data_file("completions/bash.sh")
+
+# Platform detection
+p = Platform()
+print(p.name, p.arch, p.os_version)
 ```
 
 ---

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -433,6 +433,106 @@ from rez_next.serialise_ import (
 )
 ```
 
+### Package Maker
+
+```python
+from rez_next.package_maker import PackageMaker
+
+maker = PackageMaker("my_package")
+maker.version = "1.0.0"
+maker.description = "My custom package"
+pkg = maker.build()
+```
+
+### Package Repository
+
+```python
+from rez_next.package_repository import PackageRepository
+
+repo = PackageRepository("/path/to/packages")
+for pkg in repo.iter_packages():
+    print(pkg.name, pkg.version)
+```
+
+### Build Process / Build System
+
+```python
+from rez_next.build_process import BuildProcess
+from rez_next.build_system import BuildSystem
+
+process = BuildProcess("/path/to/package")
+result = process.run()
+```
+
+### Release Hook / Release VCS
+
+```python
+from rez_next.release_hook import ReleaseHook
+from rez_next.release_vcs import get_release_vcs_types, create_release_vcs
+
+vcs_types = get_release_vcs_types()
+vcs = create_release_vcs("git")
+```
+
+### Wrapper / Bundle Context
+
+```python
+from rez_next.wrapper import Wrapper
+from rez_next.bundle_context import bundle_context
+
+w = Wrapper("/path/to/suite", "context_name", "tool_name")
+ctx = bundle_context("/path/to/context")
+```
+
+### Command / Resolver
+
+```python
+from rez_next.command import CommandResult
+from rez_next.resolver import resolve_package
+
+result = CommandResult(0, "output", "")
+ctx = resolve_package("python-3.9")
+```
+
+### Plugin Managers
+
+```python
+from rez_next.plugin_managers import PluginManager
+
+pm = PluginManager()
+pm.register("my_plugin", MyPluginClass)
+pm.activate("my_plugin")
+```
+
+### Deprecations
+
+```python
+from rez_next.deprecations import RezDeprecationWarning
+import warnings
+
+warnings.warn("old_func is deprecated", RezDeprecationWarning)
+```
+
+### Utils (Filesystem / Formatting / Logging)
+
+```python
+from rez_next.utils.filesystem import make_dirs, copy_file
+from rez_next.utils.formatting import format_table
+from rez_next.utils.logging_ import get_logger
+
+logger = get_logger(__name__)
+logger.info("Processing package...")
+```
+
+### Vendor (Version)
+
+```python
+from rez_next.vendor.version import Version
+
+v = Version("1.2.3")
+print(v.major, v.minor, v.patch)
+```
+
 ---
 
 ## CLI Reference

--- a/llms.txt
+++ b/llms.txt
@@ -48,62 +48,113 @@ crates/
 └── rez-next-python/          # PyO3 Python bindings (_native.pyd)
 ```
 
-## Python Submodules (58 files)
+## Python Submodules (56+ submodules, 67 .py files)
 
+### Core Modules
 | Module | Rez Equivalent | Key APIs |
 |--------|---------------|----------|
 | `rez_next.version` | `rez.vendor.version` | `PyVersion`, `PyVersionRange` |
 | `rez_next.packages_` | `rez.packages_` | `iter_packages`, `get_latest_package` |
 | `rez_next.packages` | `rez.packages` | Package object model |
 | `rez_next.resolved_context` | `rez.resolved_context` | `ResolvedContext`, `resolve_packages` |
+| `rez_next.config` | `rez.config` | `Config` singleton (100+ fields) |
+| `rez_next.rezconfig` | `rez.rezconfig` | Config defaults module |
+| `rez_next.system` | `rez.system` | Platform info |
+| `rez_next.shell` | `rez.shells` | Shell scripts (bash/zsh/fish/ps/cmd) |
+| `rez_next.shells` | `rez.shells` | Shell type registry |
+| `rez_next.rex` | `rez.rex` | Rex DSL interpreter |
+| `rez_next.rex_bindings` | `rez.rex_bindings` | Low-level Rex bindings |
+
+### Solver & Resolver
+| Module | Rez Equivalent | Key APIs |
+|--------|---------------|----------|
 | `rez_next.solver_` | `rez.solver` | Solver configuration |
 | `rez_next.solver` | `rez.solver` | Advanced solver API |
-| `rez_next.config` | `rez.config` | `Config` singleton |
-| `rez_next.system` | `rez.system` | Platform info |
-| `rez_next.shell` | `rez.shells` | bash/zsh/fish/ps/cmd scripts |
-| `rez_next.rex` | `rez.rex` | Rex command language |
-| `rez_next.build_` | `rez.build_` | Build system |
+| `rez_next.resolver` | `rez.resolver` | Package resolver |
+
+### Build & Release
+| Module | Rez Equivalent | Key APIs |
+|--------|---------------|----------|
+| `rez_next.build_` | `rez.build_` | Build system integration |
+| `rez_next.build_process` | `rez.build_process` | Build process orchestration |
+| `rez_next.build_system` | `rez.build_system` | Build system abstraction |
 | `rez_next.build_plugins` | `rez.build_plugins` | Build plugins |
-| `rez_next.release` | `rez.release` | Package release |
-| `rez_next.bind` | `rez.bind` | System tool binding |
-| `rez_next.pip` | `rez.pip` | pip → rez conversion |
-| `rez_next.plugins` | `rez.plugins` | Plugin management |
+| `rez_next.release` | `rez.release` | Package release workflow |
+| `rez_next.release_hook` | `rez.release_hook` | Release hooks |
+| `rez_next.release_vcs` | `rez.release_vcs` | VCS release integration |
+
+### Package Management
+| Module | Rez Equivalent | Key APIs |
+|--------|---------------|----------|
+| `rez_next.package_maker` | `rez.package_maker` | Programmatic package creation |
+| `rez_next.package_repository` | `rez.package_repository` | Package repository abstraction |
+| `rez_next.package_cache` | `rez.package_cache` | Package payload cache |
+| `rez_next.package_copy` | `rez.package_copy` | Package copying |
+| `rez_next.package_move` | `rez.package_move` | Package moving |
+| `rez_next.package_remove` | `rez.package_remove` | Package removal |
+| `rez_next.package_search` | `rez.package_search` | Package search API |
+| `rez_next.package_help` | `rez.package_help` | Package help |
+| `rez_next.package_filter` | `rez.package_filter` | Glob/Range/Regex rules |
+| `rez_next.package_order` | `rez.package_order` | Package sorting strategies |
+| `rez_next.package_resources` | `rez.package_resources` | Package resource management |
+| `rez_next.package_serialise` | `rez.package_serialise` | Package serialization |
+| `rez_next.package_test` | `rez.package_test` | Package testing runner |
+| `rez_next.package_py_utils` | `rez.package_py_utils` | package.py utilities |
+| `rez_next.package_bind` | `rez.package_bind` | Package bind utilities |
+| `rez_next.developer_package` | `rez.developer_package` | Dev workflow support |
+
+### Environment & Context
+| Module | Rez Equivalent | Key APIs |
+|--------|---------------|----------|
 | `rez_next.env` | `rez.env` | Environment creation |
 | `rez_next.source` | `rez.source` | Context activation |
 | `rez_next.bundles` | `rez.bundles` | Context bundling |
+| `rez_next.bundle_context` | `rez.bundle_context` | Relocatable bundles |
 | `rez_next.forward` | `rez.forward` | Shell forward compat |
+
+### CLI & Tools
+| Module | Rez Equivalent | Key APIs |
+|--------|---------------|----------|
+| `rez_next.cli` | `rez.cli` | CLI entry points |
 | `rez_next.search` | `rez.cli.search` | Package search |
 | `rez_next.complete` | `rez.cli.complete` | Tab completion |
 | `rez_next.diff` | `rez.cli.diff` | Context diff |
 | `rez_next.status` | `rez.cli.status` | Active context query |
 | `rez_next.depends` | `rez.cli.depends` | Reverse dependencies |
+| `rez_next.command` | `rez.utils.command` | Command execution |
+| `rez_next.wrapper` | `rez.utils.wrapper` | Tool execution wrappers |
+
+### Infrastructure
+| Module | Rez Equivalent | Key APIs |
+|--------|---------------|----------|
+| `rez_next.plugins` | `rez.plugins` | Plugin management |
+| `rez_next.plugin_managers` | `rez.plugin_managers` | Plugin manager implementations |
+| `rez_next.bind` | `rez.bind` | System tool binding |
+| `rez_next.pip` | `rez.pip` | pip → rez conversion |
+| `rez_next.serialise_` | `rez.serialise` | Serialization support |
+| `rez_next.serialise` | `rez.serialise` | Serialization bridge |
+| `rez_next.suite` | `rez.suite` | Suite management |
+| `rez_next.test` | `rez.test` | Package testing |
 | `rez_next.data` | `rez.data` | Built-in resources |
-| `rez_next.cli` | `rez.cli` | CLI entry points |
 | `rez_next.exceptions` | `rez.exceptions` | Exception hierarchy |
 | `rez_next.deprecations` | `rez.utils.deprecations` | `RezDeprecationWarning` |
-| `rez_next.package_cache` | `rez.package_cache` | Package payload cache |
-| `rez_next.package_help` | `rez.package_help` | Package help |
-| `rez_next.package_search` | `rez.package_search` | Package search API |
-| `rez_next.package_remove` | `rez.package_remove` | Package removal |
-| `rez_next.serialise_` | `rez.serialise` | Serialization |
-| `rez_next.test` | `rez.test` | Package testing |
-| `rez_next.util` | `rez.utils` | Utility functions |
-| `rez_next.suite` | `rez.suite` | Suite management |
-| `rez_next.package_maker` | `rez.package_maker` | Programmatic package creation |
-| `rez_next.package_repository` | `rez.package_repository` | Package repository |
-| `rez_next.build_process` | `rez.build_process` | Build process orchestration |
-| `rez_next.build_system` | `rez.build_system` | Build system abstraction |
-| `rez_next.release_hook` | `rez.release_hook` | Release hooks |
-| `rez_next.release_vcs` | `rez.release_vcs` | VCS release integration |
-| `rez_next.wrapper` | `rez.utils.wrapper` | Tool execution wrappers |
-| `rez_next.bundle_context` | `rez.bundle_context` | Relocatable context bundles |
-| `rez_next.command` | `rez.utils.command` | Command execution |
-| `rez_next.resolver` | `rez.resolver` | Package resolver |
-| `rez_next.plugin_managers` | `rez.plugin_managers` | Plugin manager implementations |
-| `rez_next.package_py_utils` | `rez.package_py_utils` | package.py utilities |
-| `rez_next.utils.filesystem` | `rez.utils.filesystem` | Filesystem utilities |
+
+### Utilities (`rez_next.utils.*`)
+| Module | Rez Equivalent | Key APIs |
+|--------|---------------|----------|
+| `rez_next.util` | `rez.utils` | General utilities |
+| `rez_next.utils.filesystem` | `rez.utils.filesystem` | File operations |
 | `rez_next.utils.formatting` | `rez.utils.formatting` | Output formatting |
-| `rez_next.utils.logging_` | `rez.utils.logging_` | Logging utilities |
+| `rez_next.utils.logging_` | `rez.utils.logging_` | Logging setup |
+| `rez_next.utils.resources` | `rez.utils.resources` | Resource loading |
+| `rez_next.utils.yaml` | `rez.utils.yaml` | YAML utilities |
+| `rez_next.utils.colorize` | `rez.utils.colorize` | Terminal colors |
+| `rez_next.utils.data_utils` | `rez.utils.data_utils` | Data helpers |
+| `rez_next.utils.platform_` | `rez.utils.platform_` | Platform detection |
+
+### Vendor
+| Module | Rez Equivalent | Key APIs |
+|--------|---------------|----------|
 | `rez_next.vendor.version` | `rez.vendor.version` | Vendored version module |
 
 ## Common Agent Tasks

--- a/llms.txt
+++ b/llms.txt
@@ -48,7 +48,7 @@ crates/
 └── rez-next-python/          # PyO3 Python bindings (_native.pyd)
 ```
 
-## Python Submodules (37 files)
+## Python Submodules (58 files)
 
 | Module | Rez Equivalent | Key APIs |
 |--------|---------------|----------|
@@ -89,6 +89,22 @@ crates/
 | `rez_next.test` | `rez.test` | Package testing |
 | `rez_next.util` | `rez.utils` | Utility functions |
 | `rez_next.suite` | `rez.suite` | Suite management |
+| `rez_next.package_maker` | `rez.package_maker` | Programmatic package creation |
+| `rez_next.package_repository` | `rez.package_repository` | Package repository |
+| `rez_next.build_process` | `rez.build_process` | Build process orchestration |
+| `rez_next.build_system` | `rez.build_system` | Build system abstraction |
+| `rez_next.release_hook` | `rez.release_hook` | Release hooks |
+| `rez_next.release_vcs` | `rez.release_vcs` | VCS release integration |
+| `rez_next.wrapper` | `rez.utils.wrapper` | Tool execution wrappers |
+| `rez_next.bundle_context` | `rez.bundle_context` | Relocatable context bundles |
+| `rez_next.command` | `rez.utils.command` | Command execution |
+| `rez_next.resolver` | `rez.resolver` | Package resolver |
+| `rez_next.plugin_managers` | `rez.plugin_managers` | Plugin manager implementations |
+| `rez_next.package_py_utils` | `rez.package_py_utils` | package.py utilities |
+| `rez_next.utils.filesystem` | `rez.utils.filesystem` | Filesystem utilities |
+| `rez_next.utils.formatting` | `rez.utils.formatting` | Output formatting |
+| `rez_next.utils.logging_` | `rez.utils.logging_` | Logging utilities |
+| `rez_next.vendor.version` | `rez.vendor.version` | Vendored version module |
 
 ## Common Agent Tasks
 


### PR DESCRIPTION
Expand submodule tables from 53 to 72+ entries. Add 19 missing modules across llms.txt, llms-full.txt, docs/python-integration.md, README.md/README_zh.md. Fix AGENTS.md stale counts. See commit a8933799 for details.