### PR TITLE
docs: fix outdated module/test counts and add CLI info (Run #3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,9 @@ rez-next is a **high-performance Rust rewrite** of the [Rez](https://github.com/
 - License: Apache 2.0
 - Python modules: **41 modules** (43 .py files) + **35 native** PyO3 submodules covering most Rez APIs
 - Native: **35 registered** PyO3 submodules, 28 native classes, ~50 top-level functions
-- Tests: **93 test files** (36 Python + 46 Rust + 11 fixtures)
-- Status: Many workflows work with `import rez_next as rez`, but **not yet a seamless drop-in** for every API surface
+- CLI: **28 subcommands** (config, context, view, env, release, test, build, search, bind, depends, solve, cp, mv, rm, status, diff, pkg-help, plugins, pkg-cache, suites, bundle, pip, complete, forward, gui, parse-version, self-test, self-update)
+- Tests: **82 test files** (27 Python + 46 Rust + 9 fixtures)
+- Status: Many workflows work with `import rez_next as rez`, but **not yet a seamless drop-in** for every API surface. The [`auto-improve`](https://github.com/loonghao/rez-next/tree/auto-improve) branch has 25+ additional modules in active development (62 total submodules, 56 Python tests).
 
 ## Quick Start
 
@@ -79,7 +80,7 @@ rez-next/                          # Monorepo root
 │   ├── rez-next-release-hook/    # Release hooks
 │   ├── rez-next-util/            # Utility functions
 │   └── rez-next-python/          # Python bindings (PyO3)
-├── src/                           # Rust CLI binary
+├── src/                           # Rust CLI binary (28 subcommands, entry: src/bin/rez-next.rs)
 ├── tests/                         # Integration tests
 ├── benches/                       # Criterion benchmarks
 ├── docs/                          # Documentation (see above)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ for p in rez.iter_packages("maya"):
 
 ## Feature Overview
 
-### Implemented Python Submodules (40 modules)
+### Implemented Python Submodules (41 modules)
 
 | Submodule | Equivalent rez module | Functionality |
 |-----------|----------------------|---------------|
@@ -290,7 +290,7 @@ rez-next-explicit      Explicit package lists
 rez-next-serialise     Package serialization
 rez-next-release-hook  Release hooks
 rez-next-util          Utility functions (command runner, etc.)
-rez-next-python        Python bindings via PyO3 (40 submodules)
+rez-next-python        Python bindings via PyO3 (41 submodules)
 ```
 
 ### Component status
@@ -316,7 +316,7 @@ rez-next-python        Python bindings via PyO3 (40 submodules)
 | `rez-next-serialise` | Stable | ~5 |
 | `rez-next-explicit` | Stable | ~5 |
 | `rez-next-util` | Stable | ~5 |
-| `rez-next-python` | Partial compatibility (40 submodules) | ~125 |
+| `rez-next-python` | Partial compatibility (41 submodules) | ~125 |
 | Compat integration tests | Growing coverage | ~210 |
 
 ---

--- a/README_zh.md
+++ b/README_zh.md
@@ -107,7 +107,7 @@ for p in rez.iter_packages("maya"):
 
 ## 功能概览
 
-### 已实现的 Python 子模块（40 个模块）
+### 已实现的 Python 子模块（41 个模块）
 
 | 子模块 | 等价 rez 模块 | 功能 |
 |--------|--------------|------|
@@ -290,7 +290,7 @@ rez-next-explicit      显式包列表
 rez-next-serialise     包序列化
 rez-next-release-hook  发布钩子
 rez-next-util          工具函数（命令执行等）
-rez-next-python        Python 绑定 via PyO3（40 个子模块）
+rez-next-python        Python 绑定 via PyO3（41 个子模块）
 ```
 
 ### 各组件状态
@@ -316,7 +316,7 @@ rez-next-python        Python 绑定 via PyO3（40 个子模块）
 | `rez-next-serialise` | 稳定 | ~5 |
 | `rez-next-explicit` | 稳定 | ~5 |
 | `rez-next-util` | 稳定 | ~5 |
-| `rez-next-python` | 部分兼容（40 个子模块） | ~125 |
+| `rez-next-python` | 部分兼容（41 个子模块） | ~125 |
 | Compat integration | 覆盖面持续增长 | ~210 |
 
 ---

--- a/docs/python-integration.md
+++ b/docs/python-integration.md
@@ -9,7 +9,7 @@ Python bindings are **partially implemented** in `crates/rez-next-python` and ex
 ## Architecture
 
 ```
-rez_next/                              # Main package (43 .py files, 39 modules)
+rez_next/                              # Main package (43 .py files, 41 modules)
 ├── _native.*.pyd                      # PyO3 native extension (abi3-py38)
 ├── __init__.py                        # Exports, version, drop-in shims
 ├── vendor/                            # rez_next.vendor subpackage
@@ -133,7 +133,7 @@ rez_next/                              # Main package (43 .py files, 39 modules)
 | `rez_next.utils.resources` | `rez.utils.resources` | Resource loading utilities | ✅ Stable |
 | `rez_next.vendor.version` | `rez.vendor.version` | Vendored version module | ✅ Stable |
 
-**Total: 40 modules** (38 Python .py files + 2 native-only: `version`, submodules in `_native.pyd`)
+**Total: 41 modules** (39 Python .py files + 2 native-only: `version`, submodules in `_native.pyd`)
 
 > **Note**: 25+ additional modules (`bundle_context`, `build_process`, `command`, `developer_package`, `package_bind`, `package_copy`, `package_filter`, `package_maker`, `package_move`, `package_order`, `package_resources`, `package_serialise`, `package_test`, `plugin_managers`, `release_hook`, `release_vcs`, `resolver`, `rex_bindings`, `serialise`, `shells`, `wrapper`, `utils.*` extended, `rezconfig`) are in development on the `auto-improve` branch.
 

--- a/llms.txt
+++ b/llms.txt
@@ -48,7 +48,7 @@ crates/
 └── rez-next-python/          # PyO3 Python bindings (_native.pyd)
 ```
 
-## Python Submodules (39 modules, 43 .py files)
+## Python Submodules (41 modules, 43 .py files)
 
 > **Note**: All listed modules exist on `main` branch. Additional modules (`bundle_context`, `build_process`, `command`, `developer_package`, `package_bind`, `package_copy`, `package_filter`, `package_maker`, `package_move`, `package_order`, `package_resources`, `package_serialise`, `package_test`, `plugin_managers`, `release_hook`, `release_vcs`, `resolver`, `rex_bindings`, `serialise`, `shells`, `wrapper`, `utils/*`, `rezconfig`) are in development on the `auto-improve` branch.
 


### PR DESCRIPTION
## Summary

Fix outdated numbers across all AI-facing and human documentation to match the actual state of the \main\ branch.

## Changes

### AGENTS.md
- Fix Python test count: ~~36~~ → **27** (27 test_*.py on main)
- Fix fixture count: ~~11~~ → **9**
- Fix total test files: ~~93~~ → **82** (27 + 46 + 9)
- Add CLI subcommand count (**28**) to key facts
- Add auto-improve branch context to status line (25+ modules, 62 total)
- Add CLI binary entry point detail to architecture diagram

### llms.txt
- Fix submodule count: ~~39~~ → **41** (consistent with AGENTS.md)

### README.md / README_zh.md
- Fix module count: ~~40~~ → **41** (throughout architecture, tables)
- Fix crate status table submodule count

### docs/python-integration.md
- Fix module count: ~~40~~ → **41** / ~~39~~ → **41** (in header and total line)

## Verification
- All counts verified against actual \main\ branch files
- 43 .py files total → 41 accessible modules (39 .py-based + 2 native-only)
- 27 Python test files (test_*.py in tests/)
- 46 Rust test files (tests/*.rs)
- 9 fixture .py files
- 28 CLI subcommands (verified from src/cli/mod.rs)