### PR TITLE
docs: fix module count from 41 to 40 across all docs (Run #4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ rez-next is a **high-performance Rust rewrite** of the [Rez](https://github.com/
 - Build system: Cargo workspace (20 crates) + Maturin for Python
 - Current version: 0.3.4 (see [CHANGELOG.md](./CHANGELOG.md))
 - License: Apache 2.0
-- Python modules: **41 modules** (43 .py files) + **35 native** PyO3 submodules covering most Rez APIs
+- Python modules: **40 modules** (43 .py files) + **35 native** PyO3 submodules covering most Rez APIs
 - Native: **35 registered** PyO3 submodules, 28 native classes, ~50 top-level functions
 - CLI: **28 subcommands** (config, context, view, env, release, test, build, search, bind, depends, solve, cp, mv, rm, status, diff, pkg-help, plugins, pkg-cache, suites, bundle, pip, complete, forward, gui, parse-version, self-test, self-update)
 - Tests: **82 test files** (27 Python + 46 Rust + 9 fixtures)
@@ -190,7 +190,7 @@ result = diff_contexts(["python-3.9"], ["python-3.11", "maya-2024"])
 
 ⚠️ **Not all Rez features are implemented** — check coverage before suggesting code changes
 
-⚠️ **Python bindings are partial** — `rez_next` has 41 Python modules + 35 native submodules, covering most Rez APIs but not every edge case
+⚠️ **Python bindings are partial** — `rez_next` has 40 Python modules + 35 native submodules, covering most Rez APIs but not every edge case
 
 ⚠️ **Breaking changes possible** — pre-1.0 project, API may change
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ for p in rez.iter_packages("maya"):
 
 ## Feature Overview
 
-### Implemented Python Submodules (41 modules)
+### Implemented Python Submodules (40 modules)
 
 | Submodule | Equivalent rez module | Functionality |
 |-----------|----------------------|---------------|
@@ -290,7 +290,7 @@ rez-next-explicit      Explicit package lists
 rez-next-serialise     Package serialization
 rez-next-release-hook  Release hooks
 rez-next-util          Utility functions (command runner, etc.)
-rez-next-python        Python bindings via PyO3 (41 submodules)
+rez-next-python        Python bindings via PyO3 (40 submodules)
 ```
 
 ### Component status
@@ -316,7 +316,7 @@ rez-next-python        Python bindings via PyO3 (41 submodules)
 | `rez-next-serialise` | Stable | ~5 |
 | `rez-next-explicit` | Stable | ~5 |
 | `rez-next-util` | Stable | ~5 |
-| `rez-next-python` | Partial compatibility (41 submodules) | ~125 |
+| `rez-next-python` | Partial compatibility (40 submodules) | ~125 |
 | Compat integration tests | Growing coverage | ~210 |
 
 ---

--- a/README_zh.md
+++ b/README_zh.md
@@ -107,7 +107,7 @@ for p in rez.iter_packages("maya"):
 
 ## 功能概览
 
-### 已实现的 Python 子模块（41 个模块）
+### 已实现的 Python 子模块（40 个模块）
 
 | 子模块 | 等价 rez 模块 | 功能 |
 |--------|--------------|------|
@@ -290,7 +290,7 @@ rez-next-explicit      显式包列表
 rez-next-serialise     包序列化
 rez-next-release-hook  发布钩子
 rez-next-util          工具函数（命令执行等）
-rez-next-python        Python 绑定 via PyO3（41 个子模块）
+rez-next-python        Python 绑定 via PyO3（40 个子模块）
 ```
 
 ### 各组件状态
@@ -316,7 +316,7 @@ rez-next-python        Python 绑定 via PyO3（41 个子模块）
 | `rez-next-serialise` | 稳定 | ~5 |
 | `rez-next-explicit` | 稳定 | ~5 |
 | `rez-next-util` | 稳定 | ~5 |
-| `rez-next-python` | 部分兼容（41 个子模块） | ~125 |
+| `rez-next-python` | 部分兼容（40 个子模块） | ~125 |
 | Compat integration | 覆盖面持续增长 | ~210 |
 
 ---

--- a/docs/python-integration.md
+++ b/docs/python-integration.md
@@ -9,7 +9,7 @@ Python bindings are **partially implemented** in `crates/rez-next-python` and ex
 ## Architecture
 
 ```
-rez_next/                              # Main package (43 .py files, 41 modules)
+rez_next/                              # Main package (43 .py files, 40 modules)
 ├── _native.*.pyd                      # PyO3 native extension (abi3-py38)
 ├── __init__.py                        # Exports, version, drop-in shims
 ├── vendor/                            # rez_next.vendor subpackage
@@ -46,7 +46,7 @@ rez_next/                              # Main package (43 .py files, 41 modules)
 ├── package_remove.py                  # Package removal
 ├── package_search.py                  # Package search
 ├── __main__.py                        # CLI entry points
-└── ...                                # Total: 43 .py files, 39 modules
+└── ...                                # Total: 43 .py files, 40 modules
 ```
 
 > **Note**: Additional 25+ modules (`bundle_context`, `build_process`, `command`, `developer_package`, `package_bind`, `package_copy`, `package_filter`, `package_maker`, `package_move`, `package_order`, `package_resources`, `package_serialise`, `package_test`, `plugin_managers`, `release_hook`, `release_vcs`, `resolver`, `rex_bindings`, `serialise`, `shells`, `wrapper`, `utils.*` extended, `rezconfig`) are in development on the `auto-improve` branch.
@@ -133,7 +133,7 @@ rez_next/                              # Main package (43 .py files, 41 modules)
 | `rez_next.utils.resources` | `rez.utils.resources` | Resource loading utilities | ✅ Stable |
 | `rez_next.vendor.version` | `rez.vendor.version` | Vendored version module | ✅ Stable |
 
-**Total: 41 modules** (39 Python .py files + 2 native-only: `version`, submodules in `_native.pyd`)
+**Total: 40 modules** (all from 43 .py files in the `rez_next` package)
 
 > **Note**: 25+ additional modules (`bundle_context`, `build_process`, `command`, `developer_package`, `package_bind`, `package_copy`, `package_filter`, `package_maker`, `package_move`, `package_order`, `package_resources`, `package_serialise`, `package_test`, `plugin_managers`, `release_hook`, `release_vcs`, `resolver`, `rex_bindings`, `serialise`, `shells`, `wrapper`, `utils.*` extended, `rezconfig`) are in development on the `auto-improve` branch.
 

--- a/llms.txt
+++ b/llms.txt
@@ -48,7 +48,7 @@ crates/
 └── rez-next-python/          # PyO3 Python bindings (_native.pyd)
 ```
 
-## Python Submodules (41 modules, 43 .py files)
+## Python Submodules (40 modules, 43 .py files)
 
 > **Note**: All listed modules exist on `main` branch. Additional modules (`bundle_context`, `build_process`, `command`, `developer_package`, `package_bind`, `package_copy`, `package_filter`, `package_maker`, `package_move`, `package_order`, `package_resources`, `package_serialise`, `package_test`, `plugin_managers`, `release_hook`, `release_vcs`, `resolver`, `rex_bindings`, `serialise`, `shells`, `wrapper`, `utils/*`, `rezconfig`) are in development on the `auto-improve` branch.
 


### PR DESCRIPTION
Fixed module count 41->40 across all 5 docs files. Audit: 43 .py files, 40 importable modules, 35 native submodules. Other counts unchanged.