### PR TITLE
fix(ci): ensure x86_64-pc-windows-gnu target installed for active toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: x86_64-pc-windows-gnu
+      - run: rustup target add x86_64-pc-windows-gnu
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --exclude rez-next-python --all-targets --target x86_64-pc-windows-gnu
       - run: cargo test -p rez-next-util which::tests --lib --target x86_64-pc-windows-gnu -- --test-threads=1


### PR DESCRIPTION
## Problem

The `test-win-gnu` CI job fails with `can't find crate for 'core'` and `the 'x86_64-pc-windows-gnu' target may not be installed`.

## Root Cause

The `dtolnay/rust-toolchain@1.95.0` action installs Rust 1.95.0 and adds the `x86_64-pc-windows-gnu` target for version 1.95.0. However, when a `rust-toolchain.toml` file in the repository specifies a different channel (e.g., `1.96.0` from Renovate PRs), cargo uses the overridden toolchain which does not have the GNU target installed.

From the CI logs:
```
info: syncing channel updates for 1.95.0-x86_64-pc-windows-msvc
1.95.0-x86_64-pc-windows-msvc installed - rustc 1.95.0
info: note that the toolchain '1.96.0-x86_64-pc-windows-msvc' is currently in use (overridden by 'rust-toolchain.toml')
```

## Fix

Add an explicit `rustup target add x86_64-pc-windows-gnu` step after the dtolnay action. This ensures the GNU target is installed for whichever toolchain is actually active when cargo runs, regardless of `rust-toolchain.toml` overrides.

## Related

- Issue: PIP-1625
- Failing PR: https://github.com/loonghao/rez-next/pull/192