### PR TITLE
fix: support Cargo workspace releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.4" # x-release-please-version
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["LongHao <hal.long@outlook.com>"]
@@ -57,7 +56,7 @@ tempfile = "3.20"
 
 [package]
 name = "rez-next"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-bind/Cargo.toml
+++ b/crates/rez-next-bind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-bind"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-build/Cargo.toml
+++ b/crates/rez-next-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-build"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-cache/Cargo.toml
+++ b/crates/rez-next-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-cache"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-common/Cargo.toml
+++ b/crates/rez-next-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-common"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-config/Cargo.toml
+++ b/crates/rez-next-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-config"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-context/Cargo.toml
+++ b/crates/rez-next-context/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-context"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-explicit/Cargo.toml
+++ b/crates/rez-next-explicit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-explicit"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 description = "Explicit package support for rez-next"

--- a/crates/rez-next-package-cache/Cargo.toml
+++ b/crates/rez-next-package-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-package-cache"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-package-filter/Cargo.toml
+++ b/crates/rez-next-package-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-package-filter"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-package/Cargo.toml
+++ b/crates/rez-next-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-package"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-python/Cargo.toml
+++ b/crates/rez-next-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-python"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-release-hook/Cargo.toml
+++ b/crates/rez-next-release-hook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-release-hook"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-repository/Cargo.toml
+++ b/crates/rez-next-repository/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-repository"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-rex/Cargo.toml
+++ b/crates/rez-next-rex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-rex"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-search/Cargo.toml
+++ b/crates/rez-next-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-search"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-serialise/Cargo.toml
+++ b/crates/rez-next-serialise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-serialise"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-solver/Cargo.toml
+++ b/crates/rez-next-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-solver"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-suites/Cargo.toml
+++ b/crates/rez-next-suites/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-suites"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/rez-next-util/Cargo.toml
+++ b/crates/rez-next-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-util"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 description = "Utility functions for rez-next"

--- a/crates/rez-next-version/Cargo.toml
+++ b/crates/rez-next-version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-next-version"
-version.workspace = true
+version = "0.3.4" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/scripts/check_release_versions.py
+++ b/scripts/check_release_versions.py
@@ -33,15 +33,6 @@ def marked_versions(path: Path) -> list[tuple[int, str]]:
     return versions
 
 
-def package_version(package: dict, workspace_version: str) -> str | None:
-    value = package.get("version")
-    if isinstance(value, str):
-        return value
-    if isinstance(value, dict) and value.get("workspace") is True:
-        return workspace_version
-    return None
-
-
 def dependency_tables(manifest: dict):
     for name in ("dependencies", "dev-dependencies", "build-dependencies"):
         yield manifest.get(name, {})
@@ -66,9 +57,13 @@ def main() -> int:
 
     with (ROOT / "Cargo.toml").open("rb") as stream:
         root_manifest = tomllib.load(stream)
-    cargo_version = root_manifest["workspace"]["package"]["version"]
-    if cargo_version != expected:
-        errors.append(f"Cargo workspace is {cargo_version}, expected {expected}")
+    cargo_version = root_manifest["package"].get("version")
+    if not isinstance(cargo_version, str):
+        errors.append(
+            "root Cargo package.version must be a literal string for release-please"
+        )
+    elif cargo_version != expected:
+        errors.append(f"root Cargo package is {cargo_version!r}, expected {expected}")
 
     with (ROOT / "crates/rez-next-python/pyproject.toml").open("rb") as stream:
         python_version = tomllib.load(stream)["project"]["version"]
@@ -94,9 +89,16 @@ def main() -> int:
         if not package:
             continue
         workspace_names.add(package["name"])
-        version = package_version(package, cargo_version)
-        if version != expected:
-            errors.append(f"{path.relative_to(ROOT)} package is {version}, expected {expected}")
+        version = package.get("version")
+        if not isinstance(version, str):
+            errors.append(
+                f"{path.relative_to(ROOT)} package.version must be a literal string "
+                "for release-please"
+            )
+        elif version != expected:
+            errors.append(
+                f"{path.relative_to(ROOT)} package is {version!r}, expected {expected}"
+            )
 
     for path, manifest_data in parsed_manifests:
         for dependencies in dependency_tables(manifest_data):


### PR DESCRIPTION
## Summary
- use literal Cargo package versions supported by the Release Please Rust updater
- reject workspace-inherited package versions in release consistency checks

## Validation
- release version consistency check
- actionlint and cargo fmt
- cargo clippy with all targets and features
- rustdoc with warnings denied
- full workspace test suite
- Release Please 17.6.1 dry-run against this branch (29 release-managed updates, including Cargo.lock)