### PR TITLE
fix: preserve benchmark result publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: python scripts/check_release_versions.py
+      - name: Test benchmark tooling
+        run: python -m unittest discover -s metrics/benchmarking/scripts -p "test_*.py" -v
 
   actionlint:
     name: Actionlint

--- a/justfile
+++ b/justfile
@@ -50,11 +50,15 @@ run *ARGS:
 check: fmt-check lint test
 
 # Run all CI checks locally (mirrors GitHub Actions)
-ci: version-check actionlint fmt-check lint-ci doc-check test
+ci: version-check benchmark-tools-test actionlint fmt-check lint-ci doc-check test
 
 # Check that all release-managed package versions match
 version-check:
     vx python scripts/check_release_versions.py
+
+# Validate the benchmark output parser and regression-gate contract
+benchmark-tools-test:
+    vx python -m unittest discover -s metrics/benchmarking/scripts -p "test_*.py" -v
 
 # Check documentation builds without warnings
 doc:

--- a/metrics/benchmarking/scripts/parse_criterion.py
+++ b/metrics/benchmarking/scripts/parse_criterion.py
@@ -5,10 +5,13 @@ Usage:
     cargo bench 2>&1 | python metrics/benchmarking/scripts/parse_criterion.py
     # or from file:
     python metrics/benchmarking/scripts/parse_criterion.py benchmark-quick.txt
+    # opt into a non-zero exit when regressions are present:
+    python metrics/benchmarking/scripts/parse_criterion.py --fail-on-regression benchmark-quick.txt
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import sys
@@ -18,29 +21,34 @@ from pathlib import Path
 from typing import Optional
 
 
-# Criterion output line patterns
-# Example: "version_parsing    time:   [9.088 µs 9.120 µs 9.157 µs]"
-# Example: "version_parsing    change: [-0.44% +0.71% +1.68%] (p = 0.21 > 0.05)"
-_TIME_RE = re.compile(
-    r"^(?P<name>.+?)\s+time:\s+\[(?P<low>[\d.]+)\s*(?P<low_unit>[nµm]?s)\s+"
-    r"(?P<mean>[\d.]+)\s*(?P<mean_unit>[nµm]?s)\s+"
-    r"(?P<high>[\d.]+)\s*(?P<high_unit>[nµm]?s)\]"
+# Criterion output line patterns. Grouped benchmarks print their name and timing
+# interval on separate lines, while standalone benchmarks use a single line.
+_TIME_INTERVAL = (
+    r"time:\s+\[(?P<low>[\d.]+)\s*(?P<low_unit>ps|ns|µs|us|ms|s)\s+"
+    r"(?P<mean>[\d.]+)\s*(?P<mean_unit>ps|ns|µs|us|ms|s)\s+"
+    r"(?P<high>[\d.]+)\s*(?P<high_unit>ps|ns|µs|us|ms|s)\]"
 )
+_TIME_RE = re.compile(rf"^(?P<name>.+?)\s+{_TIME_INTERVAL}")
+_TIME_ONLY_RE = re.compile(rf"^\s*{_TIME_INTERVAL}")
 _CHANGE_RE = re.compile(
-    r"^\s+change:\s+\[(?P<low_pct>[+-][\d.]+)%\s+(?P<mean_pct>[+-][\d.]+)%\s+"
-    r"(?P<high_pct>[+-][\d.]+)%\]\s+\(p\s+=\s+(?P<p>[\d.]+)"
+    r"^\s+change:\s+\[(?P<low_pct>[+\-−][\d.]+)%\s+"
+    r"(?P<mean_pct>[+\-−][\d.]+)%\s+"
+    r"(?P<high_pct>[+\-−][\d.]+)%\]\s+\(p\s+=\s+(?P<p>[\d.]+)"
 )
 _REGRESSION_RE = re.compile(r"Performance has regressed", re.IGNORECASE)
 _IMPROVED_RE = re.compile(r"Performance has improved", re.IGNORECASE)
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
 def _to_ns(value: float, unit: str) -> float:
     """Normalize any time unit to nanoseconds."""
     return {
+        "ps": value / 1_000,
         "ns": value,
         "µs": value * 1_000,
+        "us": value * 1_000,
         "ms": value * 1_000_000,
-        "s":  value * 1_000_000_000,
+        "s": value * 1_000_000_000,
     }.get(unit, value)
 
 
@@ -91,9 +99,17 @@ class BenchSuite:
 def parse(lines: list[str]) -> BenchSuite:
     suite = BenchSuite()
     pending: Optional[BenchResult] = None
+    candidate_name: Optional[str] = None
 
-    for line in lines:
-        m = _TIME_RE.match(line.strip())
+    for raw_line in lines:
+        line = _ANSI_RE.sub("", raw_line).rstrip()
+        stripped = line.strip()
+        m = _TIME_RE.match(stripped)
+        name = m["name"].strip() if m else None
+        if not m and candidate_name:
+            m = _TIME_ONLY_RE.match(line)
+            name = candidate_name if m else None
+
         if m:
             # Flush previous
             if pending:
@@ -103,26 +119,31 @@ def parse(lines: list[str]) -> BenchSuite:
             low_ns = _to_ns(float(m["low"]), m["low_unit"])
             high_ns = _to_ns(float(m["high"]), m["high_unit"])
             pending = BenchResult(
-                name=m["name"].strip(),
+                name=name or "unknown",
                 mean_ns=mean_ns,
                 low_ns=low_ns,
                 high_ns=high_ns,
                 mean_human=_fmt_ns(mean_ns),
             )
+            candidate_name = None
             continue
 
         if pending:
             c = _CHANGE_RE.match(line)
             if c:
-                pending.change_pct = float(c["mean_pct"])
+                pending.change_pct = float(c["mean_pct"].replace("−", "-"))
                 continue
             if _REGRESSION_RE.search(line):
-                pending.regression = True
-                suite.regressions.append(pending.name)
+                if not pending.regression:
+                    pending.regression = True
+                    suite.regressions.append(pending.name)
                 continue
             if _IMPROVED_RE.search(line):
                 pending.improved = True
                 continue
+
+        if stripped and not line[:1].isspace():
+            candidate_name = stripped
 
     if pending:
         suite.results.append(pending)
@@ -130,22 +151,32 @@ def parse(lines: list[str]) -> BenchSuite:
     return suite
 
 
-def main() -> None:
-    if len(sys.argv) > 1:
-        text = Path(sys.argv[1]).read_text(encoding="utf-8")
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", nargs="?", type=Path, help="Criterion output file")
+    parser.add_argument(
+        "--fail-on-regression",
+        action="store_true",
+        help="Return a non-zero exit code when regressions are detected",
+    )
+    args = parser.parse_args(argv)
+
+    if args.input:
+        text = args.input.read_text(encoding="utf-8")
     else:
         text = sys.stdin.read()
 
     suite = parse(text.splitlines())
     print(json.dumps(suite.as_dict(), indent=2, ensure_ascii=False))
 
-    # Exit non-zero if regressions detected (useful in CI)
     if suite.regressions:
         sys.stderr.write(
             f"\n[WARN] {len(suite.regressions)} regression(s): {suite.regressions}\n"
         )
-        sys.exit(1)
+        if args.fail_on_regression:
+            return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/metrics/benchmarking/scripts/test_parse_criterion.py
+++ b/metrics/benchmarking/scripts/test_parse_criterion.py
@@ -1,0 +1,91 @@
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from unittest.mock import patch
+
+from parse_criterion import main, parse
+
+
+class ParseCriterionTests(unittest.TestCase):
+    def test_parses_grouped_results_and_attributes_regressions(self) -> None:
+        suite = parse(
+            """
+rex_parser_construction time:   [1.0228 ms 1.0234 ms 1.0241 ms]
+package_creation/simple_package
+                        time:   [69.107 ns 69.206 ns 69.286 ns]
+                        change: [+11.066% +12.097% +12.790%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+package_creation/package_with_version
+                        time:   [613.17 ns 613.97 ns 614.56 ns]
+                        change: [+1.5965% +2.3301% +2.9992%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+""".splitlines()
+        )
+
+        self.assertEqual(
+            [result.name for result in suite.results],
+            [
+                "rex_parser_construction",
+                "package_creation/simple_package",
+                "package_creation/package_with_version",
+            ],
+        )
+        self.assertEqual(
+            suite.regressions,
+            [
+                "package_creation/simple_package",
+                "package_creation/package_with_version",
+            ],
+        )
+        self.assertEqual(suite.results[1].change_pct, 12.097)
+
+    def test_supports_ansi_picoseconds_and_unicode_minus(self) -> None:
+        suite = parse(
+            [
+                "\x1b[1mpackage_variants/access_variants\x1b[0m",
+                "                        time:   [703.53 ps 704.47 ps 705.51 ps]",
+                "                        change: [−0.3107% −0.0373% +0.3183%] (p = 0.82 > 0.05)",
+                "                        Performance has improved.",
+            ]
+        )
+
+        self.assertEqual(len(suite.results), 1)
+        result = suite.results[0]
+        self.assertEqual(result.name, "package_variants/access_variants")
+        self.assertAlmostEqual(result.mean_ns, 0.70447)
+        self.assertEqual(result.change_pct, -0.0373)
+        self.assertTrue(result.improved)
+
+    def test_records_each_regression_once(self) -> None:
+        suite = parse(
+            [
+                "example time: [1.0 ns 2.0 ns 3.0 ns]",
+                "Performance has regressed.",
+                "Performance has regressed.",
+            ]
+        )
+
+        self.assertEqual(suite.regressions, ["example"])
+
+    def test_cli_only_fails_on_regression_when_requested(self) -> None:
+        benchmark_output = """example time: [1.0 ns 2.0 ns 3.0 ns]
+Performance has regressed.
+"""
+
+        with (
+            patch("sys.stdin", io.StringIO(benchmark_output)),
+            redirect_stdout(io.StringIO()),
+            redirect_stderr(io.StringIO()),
+        ):
+            self.assertEqual(main([]), 0)
+
+        with (
+            patch("sys.stdin", io.StringIO(benchmark_output)),
+            redirect_stdout(io.StringIO()),
+            redirect_stderr(io.StringIO()),
+        ):
+            self.assertEqual(main(["--fail-on-regression"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- parse Criterion grouped benchmark output with correct names, units, signs, and regression attribution
- keep result parsing/reporting non-blocking while preserving an explicit strict mode
- cover the parser contract in local and GitHub CI

## Validation
- four parser and CLI contract tests
- actionlint and release version consistency
- replayed a completed 217-result Criterion job log in reporting and strict modes