### PR TITLE
fix: align release targets and Python support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,8 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: stable
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   CARGO_INCREMENTAL: 0
+  RUSTUP_TOOLCHAIN: 1.95.0
 
 jobs:
   release-version:
@@ -140,6 +141,24 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --exclude rez-next-python --all-targets
       - run: cargo test --workspace -- --test-threads=1
+
+  release-cross-targets:
+    name: Release target - ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            os: macos-14
+          - target: aarch64-pc-windows-msvc
+            os: windows-2022
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.95.0
+        with:
+          targets: ${{ matrix.target }}
+      - run: cargo check --locked --release --target ${{ matrix.target }} --bin rez-next --bin rez
 
   test-win-msvc:
     name: Test - win-msvc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   BINARY_NAME: rez-next
+  RUSTUP_TOOLCHAIN: 1.95.0
 
 jobs:
   verify-version:
@@ -209,7 +210,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Build wheels (abi3 — compatible with Python 3.8+)
+      - name: Build wheels (abi3 — compatible with Python 3.9+)
         working-directory: crates/rez-next-python
         run: vx maturin build --release --out dist --find-interpreter
 
@@ -241,7 +242,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-2022, macos-14]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
           - os: ubuntu-22.04
             name: linux

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 rez-next is a **high-performance Rust rewrite** of the [Rez](https://github.com/AcademySoftwareFoundation/rez) package manager with Python bindings. It supports common Rez workflows without mirroring Rez's internal implementation modules.
 
 **Key facts for agents:**
-- Language: Rust 2024 edition (MSRV 1.95) + Python 3.8+ bindings (PyO3 abi3)
+- Language: Rust 2024 edition (MSRV 1.95) + Python 3.9+ bindings (PyO3 abi3)
 - Build system: Cargo workspace (20 crates) + Maturin for Python
 - Current version: 0.3.5 (see [CHANGELOG.md](./CHANGELOG.md)) <!-- x-release-please-version -->
 - License: Apache 2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ categories = ["development-tools"]
 [workspace.dependencies]
 # External dependencies
 # Note: pyo3 version is managed per-crate (see crates/rez-next-python/Cargo.toml)
-# pyo3 = { version = "0.25", features = ["extension-module", "abi3-py38"] }
+# pyo3 = { version = "0.25", features = ["extension-module", "abi3-py39"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/crates/rez-next-python/Cargo.toml
+++ b/crates/rez-next-python/Cargo.toml
@@ -37,7 +37,7 @@ rez-next-package-filter = { version = "0.3.5", path = "../rez-next-package-filte
 rez-next-release-hook = { version = "0.3.5", path = "../rez-next-release-hook" } # x-release-please-version
 rez-next-explicit = { version = "0.3.5", path = "../rez-next-explicit" }
 rez-next-config = { version = "0.3.5", path = "../rez-next-config" } # x-release-please-version
-pyo3 = { version = "0.29", features = ["abi3-py38"] }
+pyo3 = { version = "0.29", features = ["abi3-py39"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/rez-next-python/pyproject.toml
+++ b/crates/rez-next-python/pyproject.toml
@@ -8,13 +8,12 @@ version = "0.3.5"  # x-release-please-version
 description = "High-performance Rust package manager with Rez-compatible workflows"
 readme = "README.md"
 license = { text = "Apache-2.0" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = []
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -53,7 +52,7 @@ addopts = "-v --tb=short"
 
 [tool.ruff]
 line-length = 100
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]

--- a/crates/rez-next-python/python/rez_next/build_plugins.py
+++ b/crates/rez-next-python/python/rez_next/build_plugins.py
@@ -16,9 +16,9 @@ import sys
 import tarfile
 import urllib.request
 import zipfile
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Sequence
 
 
 @dataclass(frozen=True)

--- a/crates/rez-next-python/python/rez_next/build_system.py
+++ b/crates/rez-next-python/python/rez_next/build_system.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 import abc
 import os
-from typing import TYPE_CHECKING, Any, Sequence, TypedDict
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, TypedDict
 
 if TYPE_CHECKING:
     import argparse

--- a/crates/rez-next-python/python/rez_next/config.py
+++ b/crates/rez-next-python/python/rez_next/config.py
@@ -25,7 +25,7 @@ import os
 import re
 import sys as _sys
 from contextlib import contextmanager
-from functools import lru_cache
+from functools import cache, lru_cache
 from inspect import ismodule
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -1311,7 +1311,7 @@ class Config:
     def _swap(self, other):
         self.__dict__, other.__dict__ = other.__dict__, self.__dict__
 
-    @lru_cache(maxsize=None)
+    @cache
     def _data_without_overrides(self):
         data, self._sourced_filepaths = _load_config_from_filepaths(self.filepaths)
         return data

--- a/crates/rez-next-python/python/rez_next/package_filter.py
+++ b/crates/rez-next-python/python/rez_next/package_filter.py
@@ -14,7 +14,7 @@ API Reference: rez.package_filter
 
 import fnmatch as _fnmatch
 import re as _re
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 
 import rez_next._native  # noqa: F401
 from rez_next._native.package_filter import PackageFilter  # noqa: F401
@@ -38,7 +38,7 @@ class Rule:
 
     name = "base"
 
-    def matches(self, package_dict: Dict[str, Any]) -> bool:
+    def matches(self, package_dict: dict[str, Any]) -> bool:
         raise NotImplementedError
 
     @property
@@ -49,7 +49,7 @@ class Rule:
     def family(self) -> Optional[str]:
         return None
 
-    def to_pod(self) -> Tuple[str, str]:
+    def to_pod(self) -> tuple[str, str]:
         return (self.name, "")
 
 
@@ -91,13 +91,13 @@ class GlobRule(Rule):
     def family(self) -> Optional[str]:
         return self._family
 
-    def matches(self, package_dict: Dict[str, Any]) -> bool:
+    def matches(self, package_dict: dict[str, Any]) -> bool:
         value = package_dict.get(self._field, "")
         if value is None:
             value = ""
         return _fnmatch.fnmatchcase(str(value), self._pattern)
 
-    def to_pod(self) -> Tuple[str, str]:
+    def to_pod(self) -> tuple[str, str]:
         return (self.name, self._pattern)
 
     def __repr__(self) -> str:
@@ -142,13 +142,13 @@ class RegexRule(Rule):
     def family(self) -> Optional[str]:
         return self._family
 
-    def matches(self, package_dict: Dict[str, Any]) -> bool:
+    def matches(self, package_dict: dict[str, Any]) -> bool:
         value = package_dict.get(self._field, "")
         if value is None:
             value = ""
         return bool(self._regex.search(str(value)))
 
-    def to_pod(self) -> Tuple[str, str]:
+    def to_pod(self) -> tuple[str, str]:
         return (self.name, self._pattern)
 
     def __repr__(self) -> str:
@@ -190,7 +190,7 @@ class RangeRule(Rule):
     def family(self) -> Optional[str]:
         return self._family
 
-    def matches(self, package_dict: Dict[str, Any]) -> bool:
+    def matches(self, package_dict: dict[str, Any]) -> bool:
         version_str = package_dict.get("version")
         if not version_str:
             return False
@@ -202,7 +202,7 @@ class RangeRule(Rule):
         except Exception:
             return False
 
-    def to_pod(self) -> Tuple[str, str]:
+    def to_pod(self) -> tuple[str, str]:
         return (self.name, self._range_str)
 
     def __repr__(self) -> str:
@@ -254,7 +254,7 @@ class TimestampRule(Rule):
     def family(self) -> Optional[str]:
         return self._family
 
-    def matches(self, package_dict: Dict[str, Any]) -> bool:
+    def matches(self, package_dict: dict[str, Any]) -> bool:
         pkg_ts = package_dict.get("timestamp")
         if pkg_ts is None:
             return False
@@ -267,7 +267,7 @@ class TimestampRule(Rule):
         except (ValueError, TypeError):
             return False
 
-    def to_pod(self) -> Tuple[str, str]:
+    def to_pod(self) -> tuple[str, str]:
         return (self.name, self.pattern)
 
     def __repr__(self) -> str:

--- a/crates/rez-next-python/python/rez_next/package_help.py
+++ b/crates/rez-next-python/python/rez_next/package_help.py
@@ -6,7 +6,7 @@ Provides PackageHelp class that matches rez's rez.package_help.PackageHelp inter
 
 import subprocess
 import webbrowser
-from typing import List, Optional, Tuple
+from typing import Optional
 
 from . import packages_ as _packages
 
@@ -78,7 +78,7 @@ class PackageHelp:
         return len(self._sections) > 0
 
     @property
-    def sections(self) -> List[Tuple[str, str]]:
+    def sections(self) -> list[tuple[str, str]]:
         """Returns a list of (name, uri) 2-tuples."""
         return self._sections
 

--- a/crates/rez-next-python/python/rez_next/package_order.py
+++ b/crates/rez-next-python/python/rez_next/package_order.py
@@ -13,7 +13,7 @@ API Reference: rez.package_order
 """
 
 from collections import OrderedDict as _OrderedDict
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import rez_next._native  # noqa: F401
 from rez_next._native.package_order import (  # noqa: F401
@@ -24,7 +24,7 @@ from rez_next._native.package_order import (  # noqa: F401
 )
 
 # Orderer registry: maps name → class for plugin-like extension
-_order_registry: Dict[str, type] = {}
+_order_registry: dict[str, type] = {}
 
 
 def register_orderer(cls: type) -> None:
@@ -41,7 +41,7 @@ def register_orderer(cls: type) -> None:
     _order_registry[str(name)] = cls
 
 
-def _build_pod(orderer) -> Dict[str, Any]:
+def _build_pod(orderer) -> dict[str, Any]:
     """Convert an orderer instance to its serializable dict form.
 
     Args:
@@ -52,7 +52,7 @@ def _build_pod(orderer) -> Dict[str, Any]:
     """
     name = getattr(orderer, "name", None)
     if name is not None:
-        pod: Dict[str, Any] = {"type": name}
+        pod: dict[str, Any] = {"type": name}
         if hasattr(orderer, "packages") and getattr(orderer, "packages") is not None:
             pod["packages"] = list(getattr(orderer, "packages"))
         if hasattr(orderer, "descending"):
@@ -67,7 +67,7 @@ def _build_pod(orderer) -> Dict[str, Any]:
     return {"type": "no_order"}
 
 
-def to_pod(orderer) -> Dict[str, Any]:
+def to_pod(orderer) -> dict[str, Any]:
     """Convert an orderer to a serializable POD dict.
 
     This matches rez.package_order.to_pod().
@@ -81,7 +81,7 @@ def to_pod(orderer) -> Dict[str, Any]:
     return _build_pod(orderer)
 
 
-def from_pod(data: Dict[str, Any]) -> Any:
+def from_pod(data: dict[str, Any]) -> Any:
     """Create an orderer from a POD dict.
 
     This matches rez.package_order.from_pod().
@@ -137,14 +137,14 @@ class PerFamilyOrder:
 
     def __init__(
         self,
-        order_dict: Dict[str, Any],
+        order_dict: dict[str, Any],
         default_order: Any = None,
     ):
         self._order_dict = _OrderedDict(order_dict)
         self._default = default_order
 
     @property
-    def packages(self) -> Optional[List[str]]:
+    def packages(self) -> Optional[list[str]]:
         return list(self._order_dict.keys()) if self._order_dict else None
 
     def get_orderer(self, package_name: str) -> Any:
@@ -153,14 +153,14 @@ class PerFamilyOrder:
             return self._order_dict[package_name]
         return self._default
 
-    def to_pod(self) -> Dict[str, Any]:
+    def to_pod(self) -> dict[str, Any]:
         """Serialize to POD format."""
-        entries: List[Dict[str, Any]] = []
+        entries: list[dict[str, Any]] = []
         for family, orderer in self._order_dict.items():
             entry = _build_pod(orderer)
             entry["packages"] = [family]
             entries.append(entry)
-        pod: Dict[str, Any] = {"type": self.name}
+        pod: dict[str, Any] = {"type": self.name}
         if entries:
             pod["entries"] = entries
         return pod
@@ -193,7 +193,7 @@ def get_orderer(
 
 
 # Default orderers
-DEFAULT_ORDERERS: List[Any] = [SortedOrder(descending=True, packages=None)]
+DEFAULT_ORDERERS: list[Any] = [SortedOrder(descending=True, packages=None)]
 
 
 # Re-export for convenience

--- a/crates/rez-next-python/python/rez_next/package_repository.py
+++ b/crates/rez-next-python/python/rez_next/package_repository.py
@@ -21,9 +21,10 @@ import abc
 import os
 import threading
 import time
+from collections.abc import Iterator
 from contextlib import contextmanager
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from rez_next.version import Version

--- a/crates/rez-next-python/python/rez_next/plugin_managers.py
+++ b/crates/rez-next-python/python/rez_next/plugin_managers.py
@@ -6,7 +6,7 @@ entry points. Provides the ``plugin_manager`` singleton used throughout
 for plugin discovery, registration, and instantiation.
 
 Key differences from Rez:
-- No vendor'd importlib_metadata fallback (Python 3.8+ stdlib)
+- No vendor'd importlib_metadata fallback (Python 3.9+ stdlib)
 - LazySingleton is local (no data_utils import chain)
 - Failed plugins are logged, not silently swallowed
 """

--- a/crates/rez-next-python/python/rez_next/rex_bindings.py
+++ b/crates/rez-next-python/python/rez_next/rex_bindings.py
@@ -13,7 +13,8 @@ Rez API: ``rez.rex_bindings``
 
 from __future__ import annotations
 
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 # ── Base class ─────────────────────────────────────────────────────────────
 

--- a/crates/rez-next-python/python/rez_next/serialise.py
+++ b/crates/rez-next-python/python/rez_next/serialise.py
@@ -17,9 +17,10 @@ from __future__ import annotations
 import io
 import os
 import tempfile
+from collections.abc import Iterator
 from contextlib import contextmanager
 from enum import Enum
-from typing import Any, Callable, Iterator, TextIO
+from typing import Any, Callable, TextIO
 
 # ── FileFormat (matches rez.serialise.FileFormat) ─────────────────────────────
 

--- a/crates/rez-next-python/python/rez_next/util.py
+++ b/crates/rez-next-python/python/rez_next/util.py
@@ -14,8 +14,9 @@ import importlib.util
 import inspect
 import math
 import re
+from collections.abc import Iterable
 from types import ModuleType
-from typing import Iterable, TypeVar
+from typing import TypeVar
 
 import rez_next._native  # noqa: F401
 import rez_next._native.util as _native_util

--- a/crates/rez-next-python/tests/test_distribution_metadata.py
+++ b/crates/rez-next-python/tests/test_distribution_metadata.py
@@ -1,0 +1,5 @@
+from importlib.metadata import metadata
+
+
+def test_python_support_starts_at_39():
+    assert metadata("rez-next")["Requires-Python"] == ">=3.9"

--- a/crates/rez-next-python/uv.lock
+++ b/crates/rez-next-python/uv.lock
@@ -1,10 +1,9 @@
 version = 1
 revision = 3
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-    "python_full_version < '3.9'",
+    "python_full_version < '3.10'",
 ]
 
 [[package]]
@@ -21,8 +20,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9' or python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -34,8 +32,7 @@ name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.9.*'",
-    "python_full_version < '3.9'",
+    "python_full_version < '3.10'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
@@ -89,24 +86,8 @@ wheels = [
 
 [[package]]
 name = "pluggy"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
-]
-
-[[package]]
-name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
@@ -132,37 +113,17 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.3.5"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pluggy", version = "1.5.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "tomli" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
-]
-
-[[package]]
-name = "pytest"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.9.*'",
+    "python_full_version < '3.10'",
 ]
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "exceptiongroup" },
     { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
     { name = "packaging" },
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pluggy" },
     { name = "pygments" },
     { name = "tomli" },
 ]
@@ -183,7 +144,7 @@ dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" } },
     { name = "packaging" },
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pluggy" },
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
@@ -194,28 +155,8 @@ wheels = [
 
 [[package]]
 name = "pytest-benchmark"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "py-cpuinfo" },
-    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" } },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/08/e6b0067efa9a1f2a1eb3043ecd8a0c48bfeb60d3255006dcc829d72d5da2/pytest-benchmark-4.0.0.tar.gz", hash = "sha256:fb0785b83efe599a6a956361c0691ae1dbb5318018561af10f3e915caa0048d1", size = 334641, upload-time = "2022-10-25T21:21:55.686Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/a1/3b70862b5b3f830f0422844f25a823d0470739d994466be9dbbbb414d85a/pytest_benchmark-4.0.0-py3-none-any.whl", hash = "sha256:fdb7db64e31c8b277dff9850d2a2556d8b60bcb0ea6524e36e28ffd7c87f71d6", size = 43951, upload-time = "2022-10-25T21:21:53.208Z" },
-]
-
-[[package]]
-name = "pytest-benchmark"
 version = "5.2.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
     { name = "py-cpuinfo" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -228,17 +169,15 @@ wheels = [
 
 [[package]]
 name = "rez-next"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 
 [package.optional-dependencies]
 test = [
     { name = "maturin" },
-    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pytest-benchmark", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest-benchmark", version = "5.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest-benchmark" },
 ]
 
 [package.metadata]
@@ -305,24 +244,8 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.13.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
-]
-
-[[package]]
-name = "typing-extensions"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },

--- a/docs/python-integration.md
+++ b/docs/python-integration.md
@@ -10,7 +10,7 @@ Python bindings expose a **curated compatibility surface** through the `rez_next
 
 ```
 rez_next/                              # Main Python package
-├── _native.*.pyd                      # PyO3 native extension (abi3-py38)
+├── _native.*.pyd                      # PyO3 native extension (abi3-py39)
 ├── __init__.py                        # Supported exports and version
 ├── vendor/                            # rez_next.vendor subpackage
 │   ├── __init__.py
@@ -232,7 +232,7 @@ print(result.format())
 ### Prerequisites
 
 - Rust 1.95+ (MSRV in `Cargo.toml`)
-- Python 3.8+
+- Python 3.9+
 - Maturin (`pip install maturin`)
 - (Optional) `vx` for tool management (see `vx.toml`)
 
@@ -313,7 +313,7 @@ See [benchmark_guide.md](./benchmark_guide.md) for details.
 1. **Not all Rez APIs implemented** - Check the table above for coverage
 2. **Some advanced APIs are excluded** - Variant URI lookup, cached pure-Python resolver execution, and direct repository variant installation fail explicitly
 3. **Pre-1.0 project** - API may change
-4. **Python 3.8+ required** - For abi3-py38 support
+4. **Python 3.9+ required** - For abi3-py39 support
 
 ## Troubleshooting
 
@@ -336,10 +336,10 @@ RUST_LOG=debug pytest tests/ -v
 
 ```bash
 # Check Python version
-python --version  # Must be 3.8+
+python --version  # Must be 3.9+
 
 # Rebuild with specific Python
-maturin develop --release --python /path/to/python3.8
+maturin develop --release --python /path/to/python3.9
 ```
 
 ## Links

--- a/docs/python-integration_zh.md
+++ b/docs/python-integration_zh.md
@@ -6,7 +6,7 @@ Python 绑定**已经实现**，位于 `crates/rez-next-python`，并通过 `rez
 
 ## 当前状态
 
-- 原生绑定基于 PyO3 构建，并使用 `abi3-py38`
+- 原生绑定基于 PyO3 构建，并使用 `abi3-py39`
 - 扩展模块暴露为 `rez_next._native`
 - Python shim 模块保持了 Rez 风格的导入接口，例如 `rez_next.version`、`rez_next.packages_`、`rez_next.resolved_context`
 - 更完整的模块矩阵与兼容性说明以根目录 `README.md` 为准

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -592,7 +592,7 @@ vx cargo clippy --workspace --all-targets
 ## Key Design Decisions
 
 1. **Drop-in replacement**: `import rez_next as rez` works for most common workflows
-2. **abi3-py38**: Single wheel for Python 3.8+, no per-version builds
+2. **abi3-py39**: Single wheel for Python 3.9+, no per-version builds
 3. **A* solver**: Guaranteed optimal solutions with configurable heuristics
 4. **Multi-level cache**: Memory (LRU) → Disk → Repository; transparent for consumers
 5. **State machine parsing**: Version parser uses a state machine for correctness

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@
 
 High-performance Rust rewrite of [Rez](https://github.com/AcademySoftwareFoundation/rez) with Python bindings (PyO3). Import as `import rez_next as rez` for most workflows.
 
-- **Language**: Rust 2024 edition (MSRV 1.95) + Python 3.8+ (abi3)
+- **Language**: Rust 2024 edition (MSRV 1.95) + Python 3.9+ (abi3)
 - **Build**: Cargo workspace (20 crates) + Maturin for Python
 - **Status**: Pre-1.0. Documented common workflows are production-ready; compatibility is curated rather than exhaustive.
 


### PR DESCRIPTION
## Summary
- require Python 3.9+ across package metadata, abi3, tooling, docs, and release tests
- keep CI and release builds on the declared Rust 1.95 toolchain
- test the two non-native release targets on pull requests

## Validation
- `vx just ci`
- `vx just py-test` (515 passed, 3 skipped)
- Windows ARM release target check with Rust 1.95